### PR TITLE
ci: bootstrap Claude Code PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,36 @@
+name: Claude Code PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - "**/*.md"
+      - "plan/**"
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude"
+          prompt: |
+            Review this pull request. Check for:
+            - Logic errors and bugs
+            - Security vulnerabilities (XSS, injection, secret leaks)
+            - Unhandled edge cases / missing error handling
+            - Readability and maintainability
+            Post inline comments on specific lines where you find issues.
+            Write a short summary at the top of your review.
+          classify_inline_comments: "true"
+          include_fix_links: "true"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
+  id-token: write # required for the action to fetch its GitHub auth token via OIDC
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
- Bootstrap PR for the Claude Code PR review workflow (`.github/workflows/claude-review.yml`).
- The action refuses to run on PRs whose workflow file differs from `main` (security: prevents fork PRs from rewriting the reviewer's prompt). So the workflow has to land on `main` before any other PR (including #102) can be auto-reviewed.
- Three commits cherry-picked from #102: initial add, `id-token: write` permission fix, and a clarifying comment.

## Test plan
- [x] Workflow YAML is syntactically valid (verified locally)
- [ ] After merge, push to #102 → workflow should run and produce an actual review on that PR
- [ ] Future PRs (e.g. next round of Coach Log work) auto-reviewed on `opened` / `synchronize`
- [ ] `@claude review` comment on any PR triggers an on-demand pass

## Setup reminder
Repo secret `ANTHROPIC_API_KEY` is already in place (verified via failed earlier runs reaching the API key step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)