### PR TITLE
ci: check out repo before running claude-review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,6 +21,9 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # action runs `git fetch origin main`; full history avoids edge cases
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Adds `actions/checkout@v4` before the Claude review action.

The action calls `git config user.name` and `git fetch origin main` internally; without a checkout, both fail with `fatal: not in a git directory`. Observed on the first real run when `@claude review` was triggered as a comment on PR #102.

`fetch-depth: 0` so the in-action `git fetch origin main --depth=1` always works regardless of how deep the action wants to go.

## Test plan
- [ ] Merge → comment `@claude review` on an existing PR → review actually posts
- [ ] No regression on PR-open / synchronize trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)