### PR TITLE
ci: tune claude-review (sonnet, max-turns, allowed_tools, full output)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,13 @@ jobs:
           trigger_phrase: "@claude"
           # Sonnet 4.6 + max-turns 20: faster + cheaper than Opus default,
           # caps runaway reviews. Tune later if review depth drops.
-          claude_args: "--model claude-sonnet-4-6 --max-turns 20"
+          # allowedTools: bounded to read-only ops Claude needs during review
+          # (the first run hit 16 permission denials and posted nothing — the
+          # CLI defaults are too restrictive for agent mode + PR review).
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 20
+            --allowedTools 'Read,Glob,Grep,Bash(git:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'
           prompt: |
             Review this pull request. Check for:
             - Logic errors and bugs

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
+          # Sonnet 4.6 + max-turns 20: faster + cheaper than Opus default,
+          # caps runaway reviews. Tune later if review depth drops.
+          claude_args: "--model claude-sonnet-4-6 --max-turns 20"
           prompt: |
             Review this pull request. Check for:
             - Logic errors and bugs
@@ -38,3 +41,6 @@ jobs:
             Write a short summary at the top of your review.
           classify_inline_comments: "true"
           include_fix_links: "true"
+          # Surface full tool-call output in the Actions log so we can see
+          # which tools get denied. Private repo so secret-leak risk is bounded.
+          show_full_output: "true"


### PR DESCRIPTION
## Summary
The first real review run on PR #102 finished without posting anything: 6.5 min runtime, \$1.82 cost, 44 turns, **16 permission denials**. Four tweaks:

- **`--allowedTools 'Read,Glob,Grep,Bash(git:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'`** — actual fix for the denials. Bounded to read-only ops Claude needs during review. No write tools.
- `--model claude-sonnet-4-6` — Sonnet is ~5x cheaper / ~2x faster than Opus.
- `--max-turns 20` — caps runaway reviews. Default appears to be ~50.
- `show_full_output: "true"` — verbose tool-call logs in case denials still happen. Private repo, secret-leak risk bounded.

All four go through `claude_args` except `show_full_output` (which is its own input — the action has no top-level `model`, `max_turns`, or `allowed_tools` input).

## Test plan
- [ ] Merge → rebase PR #102 onto main → run the review → confirm a review or summary actually posts
- [ ] If denials still happen, the full-output log will name remaining blocked tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)