### PR TITLE
ci: allow Bash(gh:*) so claude can post the review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 20
-            --allowedTools 'Read,Glob,Grep,Bash(git:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'
+            --allowedTools 'Read,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'
           prompt: |
             Review this pull request. Check for:
             - Logic errors and bugs


### PR DESCRIPTION
## Summary
With `show_full_output: true` enabled, the last run revealed the actual blocker: Claude's built-in `review` skill runs `gh pr list` / `gh pr view` / `gh pr diff` / `gh pr comment`. Our allowlist had `Bash(git:*)` but not `Bash(gh:*)`, so the first command (`gh pr list`) was denied and the skill bailed after 1 turn.

This adds `Bash(gh:*)` to the allowlist. With that, the review skill should complete and post a review comment.

## What this doesn't fix (separate concern)
The action's MCP server still isn't loading (`mcp_servers: []` in the log), so review comments come back as a single top-level comment via `gh pr comment` rather than as inline review comments. Working out the MCP wiring is a follow-up.

## Test plan
- [ ] Merge → rebase PR #102 → re-trigger → confirm a top-level review comment posts
- [ ] If still failing, the verbose log will name the next blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)