### PR TITLE
ci: claude-review summary-only (drop inline, disable sub-agents)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,23 +30,25 @@ jobs:
           trigger_phrase: "@claude"
           # Sonnet 4.6 + max-turns 20: faster + cheaper than Opus default,
           # caps runaway reviews. Tune later if review depth drops.
-          # allowedTools: bounded to read-only ops Claude needs during review
-          # (the first run hit 16 permission denials and posted nothing — the
-          # CLI defaults are too restrictive for agent mode + PR review).
+          # allowedTools: bounded to read-only ops Claude needs during review.
+          # disallowedTools 'Task': prevents sub-agent spawning. Sub-agents have
+          # their own turn budget so they bypass --max-turns. Previous run got
+          # stuck in an 18-min retry loop inside a `general-purpose` sub-agent.
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 20
             --allowedTools 'Read,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'
+            --disallowedTools 'Task'
           prompt: |
             Review this pull request. Check for:
             - Logic errors and bugs
             - Security vulnerabilities (XSS, injection, secret leaks)
             - Unhandled edge cases / missing error handling
             - Readability and maintainability
-            Post inline comments on specific lines where you find issues.
-            Write a short summary at the top of your review.
-          classify_inline_comments: "true"
-          include_fix_links: "true"
+
+            Post ONE top-level summary comment on the PR using `gh pr comment <number> --body "..."`.
+            Do NOT post inline review comments and do NOT create a pending review (`gh api .../reviews`).
+            Do NOT delegate to sub-agents.
           # Surface full tool-call output in the Actions log so we can see
           # which tools get denied. Private repo so secret-leak risk is bounded.
           show_full_output: "true"


### PR DESCRIPTION
## Summary
The previous run got stuck in an 18-minute retry loop. Root cause: Claude spawned a `general-purpose` sub-agent to "post PR review with inline comments," which has its **own** turn budget (bypassing `--max-turns 20`), and the sub-agent's `gh api .../reviews` calls kept failing because GitHub rejects inline comments on lines outside the diff hunks. Each rejection → discard pending draft → retry.

Per discussion, dropping the inline-comment ask entirely. Just a top-level summary now.

## Changes
- **Prompt rewritten**: ask for ONE top-level summary via `gh pr comment`, explicitly forbid inline reviews and sub-agent delegation.
- **`--disallowedTools 'Task'`**: enforces no sub-agent spawning. Combined with the prompt instruction, the main loop's `--max-turns 20` is the real cap now.
- Removed `classify_inline_comments` and `include_fix_links` (both buffer inline-review state — irrelevant now).

## Test plan
- [ ] Merge → rebase PR #102 → re-trigger → confirm one top-level summary comment posts within ~2 min, no draft reviews created, run completes in well under 5 min

## If inline comments are wanted later
The action ships MCP tools for inline comments that don't have the diff-hunk rejection problem. The log showed `mcp_servers: []` — the server isn't loading. That's a separate investigation; not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)