### PR TITLE
Update Alli's email in executive assistant mapping

### DIFF
--- a/app/components/weekly-project-log/utils.tsx
+++ b/app/components/weekly-project-log/utils.tsx
@@ -172,7 +172,7 @@ export const executiveAssistantMappings: ExecutiveAssistantMapping[] = [
     executiveId:"2"
   },
   {
-    executiveAssistantEmail: "alli.franken@teachinglab.org",
+    executiveAssistantEmail: "alli.betsill@teachinglab.org",
     executiveName: "Sarah Johnson",
     executiveEmail: "sarah.johnson@teachinglab.org",
     executiveId: "30"


### PR DESCRIPTION
## Summary
Alli changed her email from `alli.franken@teachinglab.org` to `alli.betsill@teachinglab.org`. This updates the `executiveAssistantMappings` entry in the weekly project log so she retains access to submit on behalf of Sarah Johnson.

Closes #112

## Changes
- `app/components/weekly-project-log/utils.tsx`: update `executiveAssistantEmail` for the Sarah Johnson mapping.

## Testing
- No behavioral change beyond the email match; Alli will now be recognized as Sarah's executive assistant when logged in with her new address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)