### PR TITLE
fix: contractor payment form bounces user to sign-in (Supabase session)

### DIFF
--- a/app/routes/api.vendor-payment-form.submit.tsx
+++ b/app/routes/api.vendor-payment-form.submit.tsx
@@ -64,7 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
     };
 
     // Initialize service and repository
-    const { supabaseClient } = createSupabaseServerClient(request);
+    const { supabaseClient, headers } = createSupabaseServerClient(request);
     const repository = vendorPaymentRepository(supabaseClient);
     const service = vendorPaymentService(repository);
 
@@ -72,10 +72,10 @@ export async function action({ request }: ActionFunctionArgs) {
     const { data, error } = await service.createSubmission(submission);
 
     if (error) {
-      return json({ error: error.message }, { status: 500 });
+      return json({ error: error.message }, { status: 500, headers });
     }
 
-    return json({ data }, { status: 201 });
+    return json({ data }, { status: 201, headers });
   } catch (error) {
     console.error("Error submitting form:", error);
     return json({ error: "Failed to submit form" }, { status: 500 });

--- a/app/routes/api.vendor-payment.delete.tsx
+++ b/app/routes/api.vendor-payment.delete.tsx
@@ -17,14 +17,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   try {
-    const { supabaseClient } = createSupabaseServerClient(request);
+    const { supabaseClient, headers } = createSupabaseServerClient(request);
     const service = vendorPaymentService(vendorPaymentRepository(supabaseClient));
     const { error } = await service.deleteSubmission(paymentRequestId);
     if (error) {
       throw error;
     }
 
-    return json({ success: true });
+    return json({ success: true }, { headers });
   } catch (error) {
     console.error("Error deleting submission:", error);
     return json({ error: "Failed to delete submission" }, { status: 500 });

--- a/app/routes/vendor-payment-form.tsx
+++ b/app/routes/vendor-payment-form.tsx
@@ -13,7 +13,7 @@ import { vendorPaymentService } from "~/domains/vendor-payment/service";
 import { LoadingSpinner } from "~/utils/LoadingSpinner";
 import { createSupabaseServerClient } from "../../supabase/supabase.server";
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  const { supabaseClient } = createSupabaseServerClient(request);
+  const { supabaseClient, headers } = createSupabaseServerClient(request);
 
   // Get cfDetails from session or wherever it's stored
   const {
@@ -27,8 +27,12 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       }
     : null;
 
+  // getSession() may rotate the refresh token; `headers` carries the resulting
+  // Set-Cookie. Returning it keeps the browser session in sync — otherwise the
+  // client's refresh token is silently invalidated and ProtectedRoute bounces
+  // the user to the sign-in page on the next auth check.
   if (!cfDetails?.email) {
-    return json({ paymentRequestHistory: [], projects: [] });
+    return json({ paymentRequestHistory: [], projects: [] }, { headers });
   }
 
   const newVendorPaymentService = vendorPaymentService(vendorPaymentRepository(supabaseClient));
@@ -42,7 +46,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const newProjectService = projectService(projectRepository());
 
   const { data: projects } = await newProjectService.fetchProjectSourceNames();
-  return json({ paymentRequestHistory, projects });
+  return json({ paymentRequestHistory, projects }, { headers });
 };
 
 export default function VendorPaymentFormRoute() {


### PR DESCRIPTION
Closes #116

## What happened
A contractor (and potentially any user) could sign in and view the dashboard, but clicking into the **Contractor Payment Form** intermittently bounced them back to the sign-in page. Confirmed the affected user's Monday/board record was valid (correct email, group, and tiers), so it was not a data or authorization problem.

## Suspected root cause
The form's loader (`app/routes/vendor-payment-form.tsx`) calls `supabaseClient.auth.getSession()` server-side but **discarded the `headers`** returned by `createSupabaseServerClient`. When the user's access token was near expiry, `getSession()` rotated the refresh token on the server and emitted new auth cookies via `Set-Cookie` into those headers — but they were never returned to the browser. The client kept the now-invalidated refresh token, its session broke on the next auth check, and `ProtectedRoute` redirected to `/` (sign-in). This route was the only one affected because it is the only one whose loader performs server-side Supabase auth. The `submit` and `delete` actions had the same latent bug (would log the user out mid-write).

## Proposed solution
Capture and return the `headers` from `createSupabaseServerClient` on every response in the affected routes so the rotated session cookies reach the browser:
- `app/routes/vendor-payment-form.tsx` — loader (both early and main returns)
- `app/routes/api.vendor-payment-form.submit.tsx` — action returns
- `app/routes/api.vendor-payment.delete.tsx` — action return

After deploy, affected users should sign out and back in once to obtain a clean session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)