### PR TITLE
ci: fix claude review max-turns failure (post via --body-file)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,8 +36,8 @@ jobs:
           # stuck in an 18-min retry loop inside a `general-purpose` sub-agent.
           claude_args: >-
             --model claude-sonnet-4-6
-            --max-turns 20
-            --allowedTools 'Read,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'
+            --max-turns 30
+            --allowedTools 'Read,Glob,Grep,Write,Bash(git:*),Bash(gh:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*)'
             --disallowedTools 'Task'
           prompt: |
             Review this pull request. Check for:
@@ -46,7 +46,12 @@ jobs:
             - Unhandled edge cases / missing error handling
             - Readability and maintainability
 
-            Post ONE top-level summary comment on the PR using `gh pr comment <number> --body "..."`.
+            Post ONE top-level summary comment on the PR. To do this reliably:
+            1. Use the Write tool to write the full markdown review to `/tmp/review.md`.
+               (Do NOT try to pass the review body inline through a shell argument —
+               backticks, quotes and ${...} in the markdown break shell quoting.)
+            2. Run exactly: `gh pr comment <number> --body-file /tmp/review.md`
+            Do NOT use heredocs, `cat >`, or python to build the comment.
             Do NOT post inline review comments and do NOT create a pending review (`gh api .../reviews`).
             Do NOT delegate to sub-agents.
           # Surface full tool-call output in the Actions log so we can see


### PR DESCRIPTION
## Problem

The `claude-review` job on PR #114 failed with `Reached maximum number of turns (20)`. The review itself completed — the failure was that Claude could never post the summary comment:

- `gh pr comment --body "<markdown>"` — the review body has backticks, quotes and `${...}`; inside a double-quoted shell arg those trigger command substitution and break quoting.
- `cat > file <<EOF … ; gh pr comment --body-file` — compound command with redirect/heredoc is rejected by the strict `--allowedTools` allowlist.
- `python3 …` fallback — `python3` isn't in the allowlist, so it was denied.

With no working post path it looped until `--max-turns` killed the job.

## Fix

- Add `Write` to `--allowedTools`.
- Instruct Claude to `Write` the review to `/tmp/review.md`, then post with a single `gh pr comment <number> --body-file /tmp/review.md` (no shell-escaping, matches the existing `Bash(gh:*)` rule).
- Bump `--max-turns` 20 → 30 as a safety margin.

## Note

This must land on `main` to take effect — the Anthropic GitHub App validates that the workflow file is identical to the default-branch copy, so the change can't be applied from a feature-branch PR. This PR won't get a Claude review on itself (expected); PRs opened after merge will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)