### PR TITLE
Coach Log Revamp FY 27 Part 3: NYC Reads & NYC Solves question sets

### DIFF
--- a/app/components/coach-log/build-submission.ts
+++ b/app/components/coach-log/build-submission.ts
@@ -1,0 +1,116 @@
+import type { CoachLogSubmission } from "~/domains/coach-log/model";
+import {
+  isNycCoachTypeDistrict,
+  shouldShowEarlyChildhood,
+  shouldShowReads,
+  shouldShowSolves,
+  shouldShowSubSchool,
+} from "./constants";
+import type { CoachLogValues } from "./use-coach-log-form";
+
+type Coach = { name: string; mondayProfileId: string };
+
+/**
+ * Maps validated form values to the flat {@link CoachLogSubmission} payload,
+ * re-applying the same show/hide gating used in the UI so values from a hidden
+ * section are never submitted. Pure (no React) so it stays easy to read and
+ * test, and keeps the form component thin.
+ */
+export function buildCoachLogSubmission(
+  values: CoachLogValues,
+  coach: Coach
+): CoachLogSubmission {
+  const cancelled = values.canceled === "Yes";
+  const showNycCoachType = isNycCoachTypeDistrict(values.district);
+  const showSubSchool = shouldShowSubSchool(values.district, values.nycCoachType);
+  const sendEC =
+    !cancelled && shouldShowEarlyChildhood(values.district, values.nycCoachType);
+  const sendReads =
+    !cancelled && shouldShowReads(values.district, values.nycCoachType);
+  const sendSolves =
+    !cancelled && shouldShowSolves(values.district, values.nycCoachType);
+  const sendCoachees = !cancelled && values.did1on1 === "Yes";
+  const sendGroup = !cancelled && values.didGroupCoaching === "Yes";
+
+  return {
+    coachName: coach.name,
+    coachMondayId: coach.mondayProfileId,
+    district: values.district,
+    school: values.school,
+    subSchool: showSubSchool ? values.subSchool : "",
+    nycCoachType: showNycCoachType ? values.nycCoachType : "",
+    sessionDate: values.sessionDate,
+
+    // ELA Early Childhood
+    ecTouchpoint: sendEC ? values.ecTouchpoint : "",
+    ecTeacherStrategies: sendEC ? values.ecTeacherStrategies : [],
+    ecLeaderCapacityFocus: sendEC ? values.ecLeaderCapacityFocus : [],
+
+    // NYC Reads
+    readsIsPLSession: sendReads ? values.readsIsPLSession : "",
+    readsScheduleProvided: sendReads ? values.readsScheduleProvided : "",
+    readsHighImpactActivities: sendReads ? values.readsHighImpactActivities : "",
+    readsTouchpoint: sendReads ? values.readsTouchpoint : "",
+    readsIsMultiSchool: sendReads ? values.readsIsMultiSchool : "",
+    readsMultiSchoolDBN: sendReads ? values.readsMultiSchoolDBN : "",
+    readsVisitDuration: sendReads ? values.readsVisitDuration : "",
+    readsSupportedTeacherTypes: sendReads ? values.readsSupportedTeacherTypes : [],
+    readsGradeBands: sendReads ? values.readsGradeBands : [],
+    readsTeacherStrategies: sendReads ? values.readsTeacherStrategies : [],
+    readsMTSSFocus: sendReads ? values.readsMTSSFocus : "",
+    readsMajorityUsingHQIM: sendReads ? values.readsMajorityUsingHQIM : "",
+    readsHQIMContext: sendReads ? values.readsHQIMContext : "",
+    readsSupportedLeaders: sendReads ? values.readsSupportedLeaders : [],
+    readsSupportedLeadersOther: sendReads ? values.readsSupportedLeadersOther : "",
+    readsLeaderVisitDuration: sendReads ? values.readsLeaderVisitDuration : "",
+    readsLeaderCapacityFocus: sendReads ? values.readsLeaderCapacityFocus : [],
+    readsSupportedDistrictLeaders: sendReads
+      ? values.readsSupportedDistrictLeaders
+      : [],
+    readsSupportedDistrictLeadersOther: sendReads
+      ? values.readsSupportedDistrictLeadersOther
+      : "",
+    readsDistrictSupports: sendReads ? values.readsDistrictSupports : [],
+    mtssPracticesResponses: sendReads ? values.mtssPracticesResponses : [],
+    mtssAdditionalContext: sendReads ? values.mtssAdditionalContext : "",
+
+    // NYC Solves
+    solvesTouchpoint: sendSolves ? values.solvesTouchpoint : "",
+    solvesTeacherVisitDuration: sendSolves ? values.solvesTeacherVisitDuration : "",
+    solvesSupportedTeacherTypes: sendSolves
+      ? values.solvesSupportedTeacherTypes
+      : [],
+    solvesGradeContentAreas: sendSolves ? values.solvesGradeContentAreas : [],
+    solvesTeacherProtocols: sendSolves ? values.solvesTeacherProtocols : [],
+    solvesIntervisitationDBNs: sendSolves ? values.solvesIntervisitationDBNs : "",
+    solvesMajorityUsingHQIM: sendSolves ? values.solvesMajorityUsingHQIM : "",
+    solvesHQIMContext: sendSolves ? values.solvesHQIMContext : "",
+    solvesLeaderSupportDuration: sendSolves
+      ? values.solvesLeaderSupportDuration
+      : "",
+    solvesLeaderSupportTrack: sendSolves ? values.solvesLeaderSupportTrack : "",
+    solvesAdditionalSupportDuration: sendSolves
+      ? values.solvesAdditionalSupportDuration
+      : "",
+    solvesAdditionalSupportType: sendSolves
+      ? values.solvesAdditionalSupportType
+      : "",
+
+    // Cancellation
+    canceled: values.canceled,
+    cancelReason: cancelled ? values.cancelReason : "",
+    cancelReasonOther: cancelled ? values.cancelReasonOther : "",
+    rescheduled: cancelled ? values.rescheduled : "",
+
+    // 1:1 coaching
+    did1on1: cancelled ? "" : values.did1on1,
+    coacheeRows: sendCoachees ? values.coacheeRows : [],
+
+    // Group coaching
+    didGroupCoaching: cancelled ? "" : values.didGroupCoaching,
+    groupParticipants: sendGroup ? values.groupParticipants : [],
+    groupParticipantRole: sendGroup ? values.groupParticipantRole : "",
+    groupTopic: sendGroup ? values.groupTopic : "",
+    groupDurationMins: sendGroup ? values.groupDurationMins : "",
+  };
+}

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -8,14 +8,19 @@ import {
   type SubSchoolMap,
 } from "~/domains/coach-log/model";
 import { useSession } from "../auth/hooks/useSession";
+import { buildCoachLogSubmission } from "./build-submission";
 import {
   isNycCoachTypeDistrict,
   shouldShowEarlyChildhood,
+  shouldShowReads,
+  shouldShowSolves,
   shouldShowSubSchool,
 } from "./constants";
 import { CancellationQuestion } from "./questions/cancellation-question";
 import { DistrictSchoolQuestion } from "./questions/district-school-question";
 import { EarlyChildhoodQuestion } from "./questions/early-childhood-question";
+import { ReadsQuestion } from "./questions/nyc/reads-question";
+import { SolvesQuestion } from "./questions/nyc/solves-question";
 import { GroupCoachingQuestion } from "./questions/group-coaching-question";
 import { NycCoachTypeQuestion } from "./questions/nyc-coach-type-question";
 import { OneOnOneCoachingQuestion } from "./questions/one-on-one-coaching-question";
@@ -57,6 +62,8 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const showNycCoachType = isNycCoachTypeDistrict(district);
   const showSubSchool = shouldShowSubSchool(district, nycCoachType);
   const showEarlyChildhood = shouldShowEarlyChildhood(district, nycCoachType);
+  const showReads = shouldShowReads(district, nycCoachType);
+  const showSolves = shouldShowSolves(district, nycCoachType);
   const showActivities = canceled !== "Yes";
 
   // Sub-school options are filtered from the loader map by district + school.
@@ -178,8 +185,6 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     }
 
     setShowErrorBanner(false);
-    const cancelledSession = values.canceled === "Yes";
-    const didGroup = !cancelledSession && values.didGroupCoaching === "Yes";
 
     try {
       setIsSubmitting(true);
@@ -189,39 +194,12 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
       const response = await fetch("/api/coach-log/submit", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          coachName: mondayProfile.name,
-          coachMondayId: mondayProfile.mondayProfileId || "",
-          district: values.district,
-          school: values.school,
-          subSchool: showSubSchool ? values.subSchool : "",
-          nycCoachType: showNycCoachType ? values.nycCoachType : "",
-          sessionDate: values.sessionDate,
-          ecTouchpoint:
-            !cancelledSession && showEarlyChildhood ? values.ecTouchpoint : "",
-          ecTeacherStrategies:
-            !cancelledSession && showEarlyChildhood
-              ? values.ecTeacherStrategies
-              : [],
-          ecLeaderCapacityFocus:
-            !cancelledSession && showEarlyChildhood
-              ? values.ecLeaderCapacityFocus
-              : [],
-          canceled: values.canceled,
-          cancelReason: cancelledSession ? values.cancelReason : "",
-          cancelReasonOther: cancelledSession ? values.cancelReasonOther : "",
-          rescheduled: cancelledSession ? values.rescheduled : "",
-          did1on1: cancelledSession ? "" : values.did1on1,
-          coacheeRows:
-            !cancelledSession && values.did1on1 === "Yes"
-              ? values.coacheeRows
-              : [],
-          didGroupCoaching: cancelledSession ? "" : values.didGroupCoaching,
-          groupParticipants: didGroup ? values.groupParticipants : [],
-          groupParticipantRole: didGroup ? values.groupParticipantRole : "",
-          groupTopic: didGroup ? values.groupTopic : "",
-          groupDurationMins: didGroup ? values.groupDurationMins : "",
-        }),
+        body: JSON.stringify(
+          buildCoachLogSubmission(values, {
+            name: mondayProfile.name,
+            mondayProfileId: mondayProfile.mondayProfileId || "",
+          })
+        ),
       });
 
       if (response.status === 207) {
@@ -286,6 +264,10 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
               />
               <GroupCoachingQuestion form={form} coacheeOptions={coacheeOptions} />
               {showEarlyChildhood && <EarlyChildhoodQuestion form={form} />}
+              {showReads && (
+                <ReadsQuestion form={form} district={district} school={school} />
+              )}
+              {showSolves && <SolvesQuestion form={form} />}
             </>
           )}
 

--- a/app/components/coach-log/constants.ts
+++ b/app/components/coach-log/constants.ts
@@ -144,3 +144,19 @@ export function shouldShowEarlyChildhood(
     nycCoachType === ELA_EARLY_CHILDHOOD_COACH_TYPE
   );
 }
+
+/** NYC Reads question set shows for a Reads coach in an NYC district. */
+export function shouldShowReads(
+  district: string,
+  nycCoachType: string
+): boolean {
+  return isNycCoachTypeDistrict(district) && nycCoachType === READS_COACH_TYPE;
+}
+
+/** NYC Solves question set shows for a Solves coach in an NYC district. */
+export function shouldShowSolves(
+  district: string,
+  nycCoachType: string
+): boolean {
+  return isNycCoachTypeDistrict(district) && nycCoachType === SOLVES_COACH_TYPE;
+}

--- a/app/components/coach-log/questions/group-coaching-question.tsx
+++ b/app/components/coach-log/questions/group-coaching-question.tsx
@@ -18,6 +18,9 @@ export const GroupCoachingQuestion = ({ form, coacheeOptions }: Props) => {
           placeholder="Select Yes or No"
           data={YES_NO_OPTIONS}
           {...form.getInputProps("didGroupCoaching")}
+          // Coerce "" -> null so a programmatic reset (e.g. PL session) clears
+          // the displayed selection (Mantine only clears on null).
+          value={form.values.didGroupCoaching || null}
         />
       </div>
 

--- a/app/components/coach-log/questions/nyc/constants.ts
+++ b/app/components/coach-log/questions/nyc/constants.ts
@@ -1,0 +1,216 @@
+// ---------------------------------------------------------------------------
+// NYC Reads & NYC Solves — option lists and conditional-display predicates.
+//
+// These two coach-type question sets are large and branch heavily on a
+// "touchpoint type" selection, so their options and show/hide rules live here,
+// away from the shared coach-log constants. The teacher-strategy and
+// leader-capacity-focus lists are shared with the ELA Early Childhood set and
+// are re-exported from the parent constants module.
+// ---------------------------------------------------------------------------
+
+import { districtKey } from "../../constants";
+
+export {
+  LEADER_CAPACITY_FOCUS_OPTIONS,
+  MAX_TEACHER_STRATEGIES,
+  TEACHER_STRATEGY_OPTIONS,
+} from "../../constants";
+
+/** Shown when an "Other" leader/district-leader option needs a write-in. */
+export const OTHER_LEADER_OPTION = "Other";
+
+// --- Shared between Reads and Solves teacher blocks ------------------------
+
+export const SUPPORTED_TEACHER_TYPE_OPTIONS = [
+  "Special Education Teachers",
+  "Paraprofessional Teachers",
+  "English as New Language or English Language Learner Teachers",
+  "Bilingual/Dual Language Teachers",
+  "None of the above",
+];
+
+// ===========================================================================
+// NYC READS
+// ===========================================================================
+
+export const READS_TOUCHPOINT_OPTIONS = [
+  "Teacher AND leader support",
+  "Teacher support ONLY",
+  "School Leader/Leadership Team support ONLY",
+  "District support",
+  "No touchpoint",
+];
+
+export const READS_VISIT_DURATION_OPTIONS = ["3", "6"];
+/** Changed for FY27: leader-visit duration is now 1–4 (was 1–6). */
+export const READS_LEADER_VISIT_DURATION_OPTIONS = ["1", "2", "3", "4"];
+
+export const READS_GRADE_BAND_OPTIONS = ["K-2", "Grades 3-5", "Grades 6-8"];
+
+export const SUPPORTED_LEADER_OPTIONS = [
+  "Principal",
+  "Assistant principal",
+  "School-based coach",
+  "District-based staff",
+  "Other",
+];
+
+export const SUPPORTED_DISTRICT_LEADER_OPTIONS = [
+  "Superintendent",
+  "Deputy Superintendent",
+  "AIS Coordinator",
+  "EDSSO",
+  "Implementation Specialist",
+  "Literacy Instructional Specialist",
+  "MLL Specialist",
+  "Other",
+];
+
+export const DISTRICT_SUPPORT_OPTIONS = [
+  "Strategic planning",
+  "Regular communication check-in",
+  "Professional learning",
+  "Data strategy",
+  "School-based learning visits",
+];
+
+const READS_TEACHER_TOUCHPOINTS = new Set([
+  "Teacher AND leader support",
+  "Teacher support ONLY",
+]);
+const READS_LEADER_TOUCHPOINTS = new Set([
+  "Teacher AND leader support",
+  "School Leader/Leadership Team support ONLY",
+]);
+
+export const readsShowsTeacherBlock = (touchpoint: string): boolean =>
+  READS_TEACHER_TOUCHPOINTS.has(touchpoint);
+export const readsShowsLeaderBlock = (touchpoint: string): boolean =>
+  READS_LEADER_TOUCHPOINTS.has(touchpoint);
+export const readsShowsDistrictBlock = (touchpoint: string): boolean =>
+  touchpoint === "District support";
+
+/** Capacity-builder questions only show for districts D9 and D75. */
+export const isReadsCapacityBuilderDistrict = (district: string): boolean =>
+  districtKey(district) === "9" || districtKey(district) === "75";
+
+// --- MTSS Pilot Schools ----------------------------------------------------
+
+export const MTSS_PRACTICE_STATEMENTS = [
+  "The school establishes and protects a consistent, designated time (e.g., SRP, WIN) at least four days per week for literacy intervention and enrichment, without replacing core instruction.",
+  "The school has identified and prepared staff members to provide interventions, ensuring they are supported through professional learning and ongoing coaching.",
+  "The school has and executes a professional learning plan, targeted to staff implementing interventions, to ensure effective delivery and monitoring.",
+  "The school has identified and leverages an existing team, inclusive of staff with expertise in SWDs and MLLs, where MTSS responsibilities are embedded.",
+  "The school uses centrally-supported and/or DOE-approved intervention programs, aligned to evidence-based practices.",
+  "The school administers Beginning of Year (BOY), Middle of Year (MOY), and End of Year (EOY) universal screeners to all eligible students.",
+  "The school uses centrally-supported and/or DOE-approved diagnostic assessments to validate the need for intervention.",
+];
+
+export const MTSS_RESPONSE_OPTIONS = [
+  "Always",
+  "Mostly",
+  "Sometimes",
+  "Not Yet",
+];
+
+/** Pilot school codes (matched against the hub's 3-digit school value), per
+ * district key. MTSS pilot questions only show for these district + school
+ * combinations. */
+const MTSS_PILOT_SCHOOLS: Record<string, string[]> = {
+  "9": ["022", "215", "303", "323", "361"],
+  "11": ["089", "108", "144", "355", "529", "175"],
+  "12": ["129", "214", "286", "318", "341"],
+  "13": ["266", "301", "113", "313", "351"],
+};
+
+/** MTSS pilot is gated on teacher/leader (not district) touchpoints. */
+const READS_MTSS_TOUCHPOINTS = new Set([
+  "Teacher AND leader support",
+  "Teacher support ONLY",
+  "School Leader/Leadership Team support ONLY",
+]);
+
+export const isMtssPilotSchool = (
+  district: string,
+  school: string
+): boolean =>
+  (MTSS_PILOT_SCHOOLS[districtKey(district)] ?? []).includes(school.trim());
+
+export const readsShowsMtssPilot = (
+  touchpoint: string,
+  district: string,
+  school: string
+): boolean =>
+  READS_MTSS_TOUCHPOINTS.has(touchpoint) && isMtssPilotSchool(district, school);
+
+// ===========================================================================
+// NYC SOLVES
+// ===========================================================================
+
+export const SOLVES_TOUCHPOINT_OPTIONS = [
+  "Teacher AND leader support",
+  "Teacher support ONLY",
+  "Leader support ONLY",
+  "Additional support to facilitate protocols",
+  "No touchpoint",
+];
+
+export const SOLVES_TEACHER_VISIT_DURATION_OPTIONS = ["3", "4", "5", "6"];
+export const SOLVES_LEADER_SUPPORT_DURATION_OPTIONS = ["1", "2", "3", "4", "5", "6"];
+export const SOLVES_ADDITIONAL_SUPPORT_DURATION_OPTIONS = ["1", "2", "3", "4", "5", "6"];
+
+export const SOLVES_GRADE_CONTENT_OPTIONS = [
+  "Middle School Math: Grades 6-8",
+  "Algebra I",
+  "Geometry",
+  "Algebra II",
+];
+
+export const SOLVES_PROTOCOL_OPTIONS = [
+  "Unit Internalization Protocol",
+  "Lesson Internalization Protocol",
+  "Do the Math Protocol",
+  "Role Play Protocol",
+  "Professional Book Club Protocol",
+  "Intervisitation Protocol",
+  "Modeling",
+  "Side-by-side coaching",
+  "Classroom visits",
+  "Unit Reflection Protocol",
+  "Student work analysis meetings",
+  "Data meetings",
+];
+export const MAX_SOLVES_PROTOCOLS = 3;
+export const SOLVES_INTERVISITATION_PROTOCOL = "Intervisitation Protocol";
+
+export const SOLVES_LEADER_SUPPORT_TRACK_OPTIONS = [
+  "Facilitated intervisitation",
+  "Unpacking teacher practice",
+  "Classroom observation & feedback practice",
+];
+
+export const SOLVES_ADDITIONAL_SUPPORT_TYPE_OPTIONS = [
+  "AP Community of Practice",
+  "Principal Professional Development",
+  "Teacher Collaborative Planning sessions",
+];
+
+const SOLVES_TEACHER_TOUCHPOINTS = new Set([
+  "Teacher AND leader support",
+  "Teacher support ONLY",
+]);
+const SOLVES_LEADER_TOUCHPOINTS = new Set([
+  "Teacher AND leader support",
+  "Leader support ONLY",
+]);
+
+export const solvesShowsTeacherBlock = (touchpoint: string): boolean =>
+  SOLVES_TEACHER_TOUCHPOINTS.has(touchpoint);
+export const solvesShowsLeaderBlock = (touchpoint: string): boolean =>
+  SOLVES_LEADER_TOUCHPOINTS.has(touchpoint);
+export const solvesShowsAdditionalSupport = (touchpoint: string): boolean =>
+  touchpoint === "Additional support to facilitate protocols";
+
+/** Shared JES Manual glossary link (Solves protocols + leader capacity focus). */
+export const JES_GLOSSARY_URL =
+  "https://docs.google.com/document/d/1WiGwohRHYmXeJztoUI0cplQ3g5inr8LjjyDChNQrDpY/edit?tab=t.0#heading=h.cslg194210x2";

--- a/app/components/coach-log/questions/nyc/field.tsx
+++ b/app/components/coach-log/questions/nyc/field.tsx
@@ -1,0 +1,25 @@
+import { Text } from "@mantine/core";
+import type { ReactNode } from "react";
+
+type Props = {
+  label: string;
+  /** Optional helper/guidance text shown under the label. */
+  note?: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * Standard label + optional note + input wrapper for the (numerous) NYC Reads
+ * and Solves questions, so each question reads as a single declarative block.
+ */
+export const QuestionField = ({ label, note, children }: Props) => (
+  <div className="flex flex-col gap-1">
+    <h1 className="font-medium text-lg">{label}</h1>
+    {note ? (
+      <Text size="sm" c="white">
+        {note}
+      </Text>
+    ) : null}
+    {children}
+  </div>
+);

--- a/app/components/coach-log/questions/nyc/mtss-pilot-question.tsx
+++ b/app/components/coach-log/questions/nyc/mtss-pilot-question.tsx
@@ -1,0 +1,59 @@
+import { Select, Text, Textarea } from "@mantine/core";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import { MTSS_PRACTICE_STATEMENTS, MTSS_RESPONSE_OPTIONS } from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/**
+ * MTSS Pilot Schools block — shown only for teacher/leader touchpoints at a
+ * pilot school. Each of the seven practice statements is rated, with an
+ * optional free-text context box at the end.
+ */
+export const MtssPilotQuestion = ({ form }: Props) => {
+  const responsesError = form.errors.mtssPracticesResponses;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl bg-white/10 p-4">
+      <div className="flex flex-col gap-1">
+        <h1 className="font-semibold text-xl">MTSS Pilot Schools</h1>
+        <Text size="sm" c="white">
+          For each practice below, select how consistently it is in place at this
+          school.
+        </Text>
+        {responsesError ? (
+          <Text size="sm" c="red">
+            {responsesError}
+          </Text>
+        ) : null}
+      </div>
+
+      {MTSS_PRACTICE_STATEMENTS.map((statement, index) => (
+        <QuestionField key={index} label={`${index + 1}. ${statement}`}>
+          <Select
+            placeholder="Select a response"
+            data={MTSS_RESPONSE_OPTIONS}
+            value={form.values.mtssPracticesResponses[index] || null}
+            onChange={(value) =>
+              form.setFieldValue(
+                `mtssPracticesResponses.${index}`,
+                value ?? ""
+              )
+            }
+          />
+        </QuestionField>
+      ))}
+
+      <QuestionField label="Please share any additional context regarding this school's MTSS practices.">
+        <Textarea
+          placeholder="Optional"
+          autosize
+          minRows={3}
+          {...form.getInputProps("mtssAdditionalContext")}
+        />
+      </QuestionField>
+    </div>
+  );
+};

--- a/app/components/coach-log/questions/nyc/reads-district-support.tsx
+++ b/app/components/coach-log/questions/nyc/reads-district-support.tsx
@@ -1,0 +1,42 @@
+import { MultiSelect, TextInput } from "@mantine/core";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  DISTRICT_SUPPORT_OPTIONS,
+  OTHER_LEADER_OPTION,
+  SUPPORTED_DISTRICT_LEADER_OPTIONS,
+} from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/** NYC Reads district-support questions (the "District support" touchpoint). */
+export const ReadsDistrictSupport = ({ form }: Props) => (
+  <>
+    <QuestionField label="Which district leaders did you build capacity with today?*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={SUPPORTED_DISTRICT_LEADER_OPTIONS}
+        {...form.getInputProps("readsSupportedDistrictLeaders")}
+      />
+    </QuestionField>
+
+    {form.values.readsSupportedDistrictLeaders.includes(OTHER_LEADER_OPTION) && (
+      <QuestionField label="Please specify other district leaders:*">
+        <TextInput
+          placeholder="Other district leaders"
+          {...form.getInputProps("readsSupportedDistrictLeadersOther")}
+        />
+      </QuestionField>
+    )}
+
+    <QuestionField label="Please select the capacity building focus provided to district leaders.*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={DISTRICT_SUPPORT_OPTIONS}
+        {...form.getInputProps("readsDistrictSupports")}
+      />
+    </QuestionField>
+  </>
+);

--- a/app/components/coach-log/questions/nyc/reads-leader-support.tsx
+++ b/app/components/coach-log/questions/nyc/reads-leader-support.tsx
@@ -1,0 +1,68 @@
+import { MultiSelect, Select, TextInput } from "@mantine/core";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  JES_GLOSSARY_URL,
+  LEADER_CAPACITY_FOCUS_OPTIONS,
+  OTHER_LEADER_OPTION,
+  READS_LEADER_VISIT_DURATION_OPTIONS,
+  SUPPORTED_LEADER_OPTIONS,
+} from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/** NYC Reads school-leader support questions (leader-inclusive touchpoints). */
+export const ReadsLeaderSupport = ({ form }: Props) => (
+  <>
+    <QuestionField label="Which school leaders/leadership team members did you build capacity with today?*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={SUPPORTED_LEADER_OPTIONS}
+        {...form.getInputProps("readsSupportedLeaders")}
+      />
+    </QuestionField>
+
+    {form.values.readsSupportedLeaders.includes(OTHER_LEADER_OPTION) && (
+      <QuestionField label="Please specify other school leaders:*">
+        <TextInput
+          placeholder="Other school leaders"
+          {...form.getInputProps("readsSupportedLeadersOther")}
+        />
+      </QuestionField>
+    )}
+
+    <QuestionField label="What was the duration of your visit with school leaders in hours?*">
+      <Select
+        placeholder="Select duration"
+        data={READS_LEADER_VISIT_DURATION_OPTIONS}
+        {...form.getInputProps("readsLeaderVisitDuration")}
+      />
+    </QuestionField>
+
+    <QuestionField
+      label="Please select the primary focus of the capacity building provided to leaders in this school.*"
+      note={
+        <>
+          See a detailed description of each capacity building focus in the{" "}
+          <a
+            href={JES_GLOSSARY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-bold underline"
+          >
+            Glossary of the JES Manual
+          </a>
+          .
+        </>
+      }
+    >
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={LEADER_CAPACITY_FOCUS_OPTIONS}
+        {...form.getInputProps("readsLeaderCapacityFocus")}
+      />
+    </QuestionField>
+  </>
+);

--- a/app/components/coach-log/questions/nyc/reads-question.tsx
+++ b/app/components/coach-log/questions/nyc/reads-question.tsx
@@ -31,14 +31,15 @@ export const ReadsQuestion = ({ form, district, school }: Props) => {
   const touchpoint = form.values.readsTouchpoint;
 
   // A Professional Learning Session isn't a coaching activity, so selecting
-  // "Yes" auto-answers the 1:1 and group coaching questions "No".
+  // "Yes" auto-answers the 1:1 and group coaching questions "No". Switching the
+  // answer back off clears those again so the coach isn't left with a silent,
+  // unintended "No".
   const handlePLSessionChange = (value: string | null) => {
     const next = (value ?? "") as YesNo | "";
     form.setFieldValue("readsIsPLSession", next);
-    if (next === "Yes") {
-      form.setFieldValue("did1on1", "No");
-      form.setFieldValue("didGroupCoaching", "No");
-    }
+    const autoAnswer = next === "Yes" ? "No" : "";
+    form.setFieldValue("did1on1", autoAnswer);
+    form.setFieldValue("didGroupCoaching", autoAnswer);
   };
 
   return (

--- a/app/components/coach-log/questions/nyc/reads-question.tsx
+++ b/app/components/coach-log/questions/nyc/reads-question.tsx
@@ -1,0 +1,91 @@
+import { Select } from "@mantine/core";
+import type { YesNo } from "~/domains/coach-log/model";
+import { YES_NO_OPTIONS } from "../../constants";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  isReadsCapacityBuilderDistrict,
+  READS_TOUCHPOINT_OPTIONS,
+  readsShowsDistrictBlock,
+  readsShowsLeaderBlock,
+  readsShowsMtssPilot,
+  readsShowsTeacherBlock,
+} from "./constants";
+import { QuestionField } from "./field";
+import { MtssPilotQuestion } from "./mtss-pilot-question";
+import { ReadsDistrictSupport } from "./reads-district-support";
+import { ReadsLeaderSupport } from "./reads-leader-support";
+import { ReadsTeacherSupport } from "./reads-teacher-support";
+
+type Props = {
+  form: CoachLogForm;
+  district: string;
+  school: string;
+};
+
+/**
+ * NYC Reads coach question set. Orchestrates the standalone questions (PL
+ * session, capacity-builder, touchpoint) and delegates each touchpoint branch
+ * to a focused sub-block.
+ */
+export const ReadsQuestion = ({ form, district, school }: Props) => {
+  const touchpoint = form.values.readsTouchpoint;
+
+  // A Professional Learning Session isn't a coaching activity, so selecting
+  // "Yes" auto-answers the 1:1 and group coaching questions "No".
+  const handlePLSessionChange = (value: string | null) => {
+    const next = (value ?? "") as YesNo | "";
+    form.setFieldValue("readsIsPLSession", next);
+    if (next === "Yes") {
+      form.setFieldValue("did1on1", "No");
+      form.setFieldValue("didGroupCoaching", "No");
+    }
+  };
+
+  return (
+    <>
+      <QuestionField label="Are you logging a Professional Learning Session?*">
+        <Select
+          placeholder="Select Yes or No"
+          data={YES_NO_OPTIONS}
+          value={form.values.readsIsPLSession || null}
+          onChange={handlePLSessionChange}
+          error={form.errors.readsIsPLSession}
+        />
+      </QuestionField>
+
+      {isReadsCapacityBuilderDistrict(district) && (
+        <>
+          <QuestionField label="Did the capacity builders provide a schedule prior to the visit?*">
+            <Select
+              placeholder="Select Yes or No"
+              data={YES_NO_OPTIONS}
+              {...form.getInputProps("readsScheduleProvided")}
+            />
+          </QuestionField>
+          <QuestionField label="Did the capacity builder attend 2-3 high-impact activities during the coaching day?*">
+            <Select
+              placeholder="Select Yes or No"
+              data={YES_NO_OPTIONS}
+              {...form.getInputProps("readsHighImpactActivities")}
+            />
+          </QuestionField>
+        </>
+      )}
+
+      <QuestionField label="What types of NYC Reads touchpoint are you recording?*">
+        <Select
+          placeholder="Select a touchpoint type"
+          data={READS_TOUCHPOINT_OPTIONS}
+          {...form.getInputProps("readsTouchpoint")}
+        />
+      </QuestionField>
+
+      {readsShowsTeacherBlock(touchpoint) && <ReadsTeacherSupport form={form} />}
+      {readsShowsLeaderBlock(touchpoint) && <ReadsLeaderSupport form={form} />}
+      {readsShowsDistrictBlock(touchpoint) && <ReadsDistrictSupport form={form} />}
+      {readsShowsMtssPilot(touchpoint, district, school) && (
+        <MtssPilotQuestion form={form} />
+      )}
+    </>
+  );
+};

--- a/app/components/coach-log/questions/nyc/reads-teacher-support.tsx
+++ b/app/components/coach-log/questions/nyc/reads-teacher-support.tsx
@@ -1,0 +1,98 @@
+import { MultiSelect, Select, Textarea, TextInput } from "@mantine/core";
+import { YES_NO_OPTIONS } from "../../constants";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  MAX_TEACHER_STRATEGIES,
+  READS_GRADE_BAND_OPTIONS,
+  READS_VISIT_DURATION_OPTIONS,
+  SUPPORTED_TEACHER_TYPE_OPTIONS,
+  TEACHER_STRATEGY_OPTIONS,
+} from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/** NYC Reads teacher-team support questions (teacher-inclusive touchpoints). */
+export const ReadsTeacherSupport = ({ form }: Props) => (
+  <>
+    <QuestionField label="Is this a multi-school support visit?*">
+      <Select
+        placeholder="Select Yes or No"
+        data={YES_NO_OPTIONS}
+        {...form.getInputProps("readsIsMultiSchool")}
+      />
+    </QuestionField>
+
+    {form.values.readsIsMultiSchool === "Yes" && (
+      <QuestionField label="Please list the DBN of all the schools supported on this multi-school visit.*">
+        <TextInput
+          placeholder="e.g. 09X022, 09X011"
+          {...form.getInputProps("readsMultiSchoolDBN")}
+        />
+      </QuestionField>
+    )}
+
+    <QuestionField label="What was the duration of this visit in hours?*">
+      <Select
+        placeholder="Select duration"
+        data={READS_VISIT_DURATION_OPTIONS}
+        {...form.getInputProps("readsVisitDuration")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Did you support any of the following teachers during this visit?*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={SUPPORTED_TEACHER_TYPE_OPTIONS}
+        {...form.getInputProps("readsSupportedTeacherTypes")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Select the grade bands you supported today.*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={READS_GRADE_BAND_OPTIONS}
+        {...form.getInputProps("readsGradeBands")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Please select the 1–5 strategies you used to build capacity with teacher teams today.*">
+      <MultiSelect
+        placeholder="Select up to 5 strategies"
+        data={TEACHER_STRATEGY_OPTIONS}
+        maxValues={MAX_TEACHER_STRATEGIES}
+        searchable
+        {...form.getInputProps("readsTeacherStrategies")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Did you explicitly focus on components of the MTSS framework during your visit?*">
+      <Select
+        placeholder="Select Yes or No"
+        data={YES_NO_OPTIONS}
+        {...form.getInputProps("readsMTSSFocus")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Were a majority of the teachers you worked with today using HQIM?*">
+      <Select
+        placeholder="Select Yes or No"
+        data={YES_NO_OPTIONS}
+        {...form.getInputProps("readsMajorityUsingHQIM")}
+      />
+    </QuestionField>
+
+    {form.values.readsMajorityUsingHQIM === "No" && (
+      <QuestionField label="Because a majority of teachers were NOT using HQIM during your visit, please share additional context on your response.*">
+        <Textarea
+          placeholder="Describe what you saw when you would have expected to see HQIM in place."
+          autosize
+          minRows={3}
+          {...form.getInputProps("readsHQIMContext")}
+        />
+      </QuestionField>
+    )}
+  </>
+);

--- a/app/components/coach-log/questions/nyc/solves-additional-support.tsx
+++ b/app/components/coach-log/questions/nyc/solves-additional-support.tsx
@@ -1,0 +1,32 @@
+import { Select } from "@mantine/core";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  SOLVES_ADDITIONAL_SUPPORT_DURATION_OPTIONS,
+  SOLVES_ADDITIONAL_SUPPORT_TYPE_OPTIONS,
+} from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/** NYC Solves "Additional support to facilitate protocols" questions. */
+export const SolvesAdditionalSupport = ({ form }: Props) => (
+  <>
+    <QuestionField label="What was the duration of your additional facilitation support during this visit in hours?*">
+      <Select
+        placeholder="Select duration"
+        data={SOLVES_ADDITIONAL_SUPPORT_DURATION_OPTIONS}
+        {...form.getInputProps("solvesAdditionalSupportDuration")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Please select which additional support you provided during this visit.*">
+      <Select
+        placeholder="Select a support type"
+        data={SOLVES_ADDITIONAL_SUPPORT_TYPE_OPTIONS}
+        {...form.getInputProps("solvesAdditionalSupportType")}
+      />
+    </QuestionField>
+  </>
+);

--- a/app/components/coach-log/questions/nyc/solves-leader-support.tsx
+++ b/app/components/coach-log/questions/nyc/solves-leader-support.tsx
@@ -1,0 +1,32 @@
+import { Select } from "@mantine/core";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  SOLVES_LEADER_SUPPORT_DURATION_OPTIONS,
+  SOLVES_LEADER_SUPPORT_TRACK_OPTIONS,
+} from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/** NYC Solves school-leader support questions (leader-inclusive touchpoints). */
+export const SolvesLeaderSupport = ({ form }: Props) => (
+  <>
+    <QuestionField label="What was the duration of your support for school leaders during this visit in hours?*">
+      <Select
+        placeholder="Select duration"
+        data={SOLVES_LEADER_SUPPORT_DURATION_OPTIONS}
+        {...form.getInputProps("solvesLeaderSupportDuration")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Please select the track of support used to support leaders in this visit.*">
+      <Select
+        placeholder="Select a track"
+        data={SOLVES_LEADER_SUPPORT_TRACK_OPTIONS}
+        {...form.getInputProps("solvesLeaderSupportTrack")}
+      />
+    </QuestionField>
+  </>
+);

--- a/app/components/coach-log/questions/nyc/solves-question.tsx
+++ b/app/components/coach-log/questions/nyc/solves-question.tsx
@@ -1,0 +1,45 @@
+import { Select } from "@mantine/core";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  SOLVES_TOUCHPOINT_OPTIONS,
+  solvesShowsAdditionalSupport,
+  solvesShowsLeaderBlock,
+  solvesShowsTeacherBlock,
+} from "./constants";
+import { QuestionField } from "./field";
+import { SolvesAdditionalSupport } from "./solves-additional-support";
+import { SolvesLeaderSupport } from "./solves-leader-support";
+import { SolvesTeacherSupport } from "./solves-teacher-support";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/**
+ * NYC Solves coach question set. Branches on the touchpoint type into teacher,
+ * leader, and additional-support sub-blocks.
+ */
+export const SolvesQuestion = ({ form }: Props) => {
+  const touchpoint = form.values.solvesTouchpoint;
+
+  return (
+    <>
+      <QuestionField
+        label="What types of NYC Solves touchpoint are you recording?*"
+        note="If you provided leader-specific support during this visit, you'll be asked about it after your teacher support. If you only debriefed teacher support with a school leader or had no leader interaction, select 'Teacher support ONLY'."
+      >
+        <Select
+          placeholder="Select a touchpoint type"
+          data={SOLVES_TOUCHPOINT_OPTIONS}
+          {...form.getInputProps("solvesTouchpoint")}
+        />
+      </QuestionField>
+
+      {solvesShowsTeacherBlock(touchpoint) && <SolvesTeacherSupport form={form} />}
+      {solvesShowsLeaderBlock(touchpoint) && <SolvesLeaderSupport form={form} />}
+      {solvesShowsAdditionalSupport(touchpoint) && (
+        <SolvesAdditionalSupport form={form} />
+      )}
+    </>
+  );
+};

--- a/app/components/coach-log/questions/nyc/solves-teacher-support.tsx
+++ b/app/components/coach-log/questions/nyc/solves-teacher-support.tsx
@@ -1,0 +1,102 @@
+import { MultiSelect, Select, Textarea, TextInput } from "@mantine/core";
+import { YES_NO_OPTIONS } from "../../constants";
+import type { CoachLogForm } from "../../use-coach-log-form";
+import {
+  JES_GLOSSARY_URL,
+  MAX_SOLVES_PROTOCOLS,
+  SOLVES_GRADE_CONTENT_OPTIONS,
+  SOLVES_INTERVISITATION_PROTOCOL,
+  SOLVES_PROTOCOL_OPTIONS,
+  SOLVES_TEACHER_VISIT_DURATION_OPTIONS,
+  SUPPORTED_TEACHER_TYPE_OPTIONS,
+} from "./constants";
+import { QuestionField } from "./field";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+/** NYC Solves teacher support questions (teacher-inclusive touchpoints). */
+export const SolvesTeacherSupport = ({ form }: Props) => (
+  <>
+    <QuestionField label="What was the duration of this visit in hours?*">
+      <Select
+        placeholder="Select duration"
+        data={SOLVES_TEACHER_VISIT_DURATION_OPTIONS}
+        {...form.getInputProps("solvesTeacherVisitDuration")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Did you support any of the following teachers during this visit?*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={SUPPORTED_TEACHER_TYPE_OPTIONS}
+        {...form.getInputProps("solvesSupportedTeacherTypes")}
+      />
+    </QuestionField>
+
+    <QuestionField label="Select ALL the grades/content areas you supported with teachers today.*">
+      <MultiSelect
+        placeholder="Select all that apply"
+        data={SOLVES_GRADE_CONTENT_OPTIONS}
+        {...form.getInputProps("solvesGradeContentAreas")}
+      />
+    </QuestionField>
+
+    <QuestionField
+      label="Please select the 1–3 primary protocols/strategies used to support teachers in this visit.*"
+      note={
+        <>
+          Make sure to select "Intervisitation Protocol" if you supported
+          multiple schools in a single visit. See a detailed description of each
+          in the{" "}
+          <a
+            href={JES_GLOSSARY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-bold underline"
+          >
+            Glossary of the JES Manual
+          </a>
+          .
+        </>
+      }
+    >
+      <MultiSelect
+        placeholder="Select up to 3 protocols"
+        data={SOLVES_PROTOCOL_OPTIONS}
+        maxValues={MAX_SOLVES_PROTOCOLS}
+        searchable
+        {...form.getInputProps("solvesTeacherProtocols")}
+      />
+    </QuestionField>
+
+    {form.values.solvesTeacherProtocols.includes(SOLVES_INTERVISITATION_PROTOCOL) && (
+      <QuestionField label="Please list the DBN's of all the schools participating in the intervisitation.*">
+        <TextInput
+          placeholder="e.g. 09X022, 09X011"
+          {...form.getInputProps("solvesIntervisitationDBNs")}
+        />
+      </QuestionField>
+    )}
+
+    <QuestionField label="Were a majority of the teachers you worked with today using HQIM?*">
+      <Select
+        placeholder="Select Yes or No"
+        data={YES_NO_OPTIONS}
+        {...form.getInputProps("solvesMajorityUsingHQIM")}
+      />
+    </QuestionField>
+
+    {form.values.solvesMajorityUsingHQIM === "No" && (
+      <QuestionField label="Because a majority of teachers were NOT using HQIM during your visit, please share additional context on your response.*">
+        <Textarea
+          placeholder="Describe what you saw when you would have expected to see HQIM in place."
+          autosize
+          minRows={3}
+          {...form.getInputProps("solvesHQIMContext")}
+        />
+      </QuestionField>
+    )}
+  </>
+);

--- a/app/components/coach-log/questions/one-on-one-coaching-question.tsx
+++ b/app/components/coach-log/questions/one-on-one-coaching-question.tsx
@@ -34,6 +34,9 @@ export const OneOnOneCoachingQuestion = ({
           placeholder="Select Yes or No"
           data={YES_NO_OPTIONS}
           {...form.getInputProps("did1on1")}
+          // Coerce "" -> null so a programmatic reset (e.g. PL session) clears
+          // the displayed selection (Mantine only clears on null).
+          value={form.values.did1on1 || null}
         />
       </div>
 

--- a/app/components/coach-log/use-coach-log-form.ts
+++ b/app/components/coach-log/use-coach-log-form.ts
@@ -6,7 +6,21 @@ import {
   ecShowsTeacherStrategies,
   isNycCoachTypeDistrict,
   shouldShowEarlyChildhood,
+  shouldShowReads,
+  shouldShowSolves,
 } from "./constants";
+import {
+  isReadsCapacityBuilderDistrict,
+  OTHER_LEADER_OPTION,
+  readsShowsDistrictBlock,
+  readsShowsLeaderBlock,
+  readsShowsMtssPilot,
+  readsShowsTeacherBlock,
+  SOLVES_INTERVISITATION_PROTOCOL,
+  solvesShowsAdditionalSupport,
+  solvesShowsLeaderBlock,
+  solvesShowsTeacherBlock,
+} from "./questions/nyc/constants";
 
 /** Single source of truth for every Coach Log field. */
 export type CoachLogValues = {
@@ -21,6 +35,44 @@ export type CoachLogValues = {
   ecTouchpoint: string;
   ecTeacherStrategies: string[];
   ecLeaderCapacityFocus: string[];
+
+  // NYC Reads coach
+  readsIsPLSession: YesNo | "";
+  readsScheduleProvided: YesNo | "";
+  readsHighImpactActivities: YesNo | "";
+  readsTouchpoint: string;
+  readsIsMultiSchool: YesNo | "";
+  readsMultiSchoolDBN: string;
+  readsVisitDuration: string;
+  readsSupportedTeacherTypes: string[];
+  readsGradeBands: string[];
+  readsTeacherStrategies: string[];
+  readsMTSSFocus: YesNo | "";
+  readsMajorityUsingHQIM: YesNo | "";
+  readsHQIMContext: string;
+  readsSupportedLeaders: string[];
+  readsSupportedLeadersOther: string;
+  readsLeaderVisitDuration: string;
+  readsLeaderCapacityFocus: string[];
+  readsSupportedDistrictLeaders: string[];
+  readsSupportedDistrictLeadersOther: string;
+  readsDistrictSupports: string[];
+  mtssPracticesResponses: string[];
+  mtssAdditionalContext: string;
+
+  // NYC Solves coach
+  solvesTouchpoint: string;
+  solvesTeacherVisitDuration: string;
+  solvesSupportedTeacherTypes: string[];
+  solvesGradeContentAreas: string[];
+  solvesTeacherProtocols: string[];
+  solvesIntervisitationDBNs: string;
+  solvesMajorityUsingHQIM: YesNo | "";
+  solvesHQIMContext: string;
+  solvesLeaderSupportDuration: string;
+  solvesLeaderSupportTrack: string;
+  solvesAdditionalSupportDuration: string;
+  solvesAdditionalSupportType: string;
 
   // Cancellation
   canceled: YesNo | "";
@@ -57,6 +109,40 @@ const INITIAL_VALUES: CoachLogValues = {
   ecTouchpoint: "",
   ecTeacherStrategies: [],
   ecLeaderCapacityFocus: [],
+  readsIsPLSession: "",
+  readsScheduleProvided: "",
+  readsHighImpactActivities: "",
+  readsTouchpoint: "",
+  readsIsMultiSchool: "",
+  readsMultiSchoolDBN: "",
+  readsVisitDuration: "",
+  readsSupportedTeacherTypes: [],
+  readsGradeBands: [],
+  readsTeacherStrategies: [],
+  readsMTSSFocus: "",
+  readsMajorityUsingHQIM: "",
+  readsHQIMContext: "",
+  readsSupportedLeaders: [],
+  readsSupportedLeadersOther: "",
+  readsLeaderVisitDuration: "",
+  readsLeaderCapacityFocus: [],
+  readsSupportedDistrictLeaders: [],
+  readsSupportedDistrictLeadersOther: "",
+  readsDistrictSupports: [],
+  mtssPracticesResponses: ["", "", "", "", "", "", ""],
+  mtssAdditionalContext: "",
+  solvesTouchpoint: "",
+  solvesTeacherVisitDuration: "",
+  solvesSupportedTeacherTypes: [],
+  solvesGradeContentAreas: [],
+  solvesTeacherProtocols: [],
+  solvesIntervisitationDBNs: "",
+  solvesMajorityUsingHQIM: "",
+  solvesHQIMContext: "",
+  solvesLeaderSupportDuration: "",
+  solvesLeaderSupportTrack: "",
+  solvesAdditionalSupportDuration: "",
+  solvesAdditionalSupportType: "",
   canceled: "",
   cancelReason: "",
   cancelReasonOther: "",
@@ -78,6 +164,15 @@ const whenNotCancelled =
   (rule: (value: any, values: CoachLogValues) => string | null) =>
   (value: any, values: CoachLogValues) =>
     values.canceled === "Yes" ? null : rule(value, values);
+
+const readsShown = (v: CoachLogValues) =>
+  shouldShowReads(v.district, v.nycCoachType);
+const solvesShown = (v: CoachLogValues) =>
+  shouldShowSolves(v.district, v.nycCoachType);
+
+const PICK_YES_NO = "Please select Yes or No";
+const PICK_ONE = "Please select an option";
+const PICK_AT_LEAST_ONE = "Please select at least one option";
 
 export function useCoachLogForm() {
   return useForm<CoachLogValues>({
@@ -109,6 +204,217 @@ export function useCoachLogForm() {
         ecShowsLeaderCapacity(values.ecTouchpoint) &&
         value.length === 0
           ? "Please select at least one focus area"
+          : null
+      ),
+
+      // --- NYC Reads ----------------------------------------------------
+      readsIsPLSession: whenNotCancelled((value, values) =>
+        readsShown(values) && !value ? PICK_YES_NO : null
+      ),
+      readsScheduleProvided: whenNotCancelled((value, values) =>
+        readsShown(values) &&
+        isReadsCapacityBuilderDistrict(values.district) &&
+        !value
+          ? PICK_YES_NO
+          : null
+      ),
+      readsHighImpactActivities: whenNotCancelled((value, values) =>
+        readsShown(values) &&
+        isReadsCapacityBuilderDistrict(values.district) &&
+        !value
+          ? PICK_YES_NO
+          : null
+      ),
+      readsTouchpoint: whenNotCancelled((value, values) =>
+        readsShown(values) && !value ? "Please select a touchpoint type" : null
+      ),
+      readsIsMultiSchool: whenNotCancelled((value, values) =>
+        readsShown(values) && readsShowsTeacherBlock(values.readsTouchpoint) && !value
+          ? PICK_YES_NO
+          : null
+      ),
+      readsMultiSchoolDBN: whenNotCancelled((value, values) =>
+        readsShown(values) &&
+        readsShowsTeacherBlock(values.readsTouchpoint) &&
+        values.readsIsMultiSchool === "Yes" &&
+        !value
+          ? "Please list the school DBNs"
+          : null
+      ),
+      readsVisitDuration: whenNotCancelled((value, values) =>
+        readsShown(values) && readsShowsTeacherBlock(values.readsTouchpoint) && !value
+          ? PICK_ONE
+          : null
+      ),
+      readsSupportedTeacherTypes: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsTeacherBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      readsGradeBands: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsTeacherBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      readsTeacherStrategies: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsTeacherBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? "Please select at least one strategy"
+          : null
+      ),
+      readsMTSSFocus: whenNotCancelled((value, values) =>
+        readsShown(values) && readsShowsTeacherBlock(values.readsTouchpoint) && !value
+          ? PICK_YES_NO
+          : null
+      ),
+      readsMajorityUsingHQIM: whenNotCancelled((value, values) =>
+        readsShown(values) && readsShowsTeacherBlock(values.readsTouchpoint) && !value
+          ? PICK_YES_NO
+          : null
+      ),
+      readsHQIMContext: whenNotCancelled((value, values) =>
+        readsShown(values) &&
+        readsShowsTeacherBlock(values.readsTouchpoint) &&
+        values.readsMajorityUsingHQIM === "No" &&
+        !value
+          ? "Please share additional context"
+          : null
+      ),
+      readsSupportedLeaders: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsLeaderBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      readsSupportedLeadersOther: whenNotCancelled((value, values) =>
+        readsShown(values) &&
+        readsShowsLeaderBlock(values.readsTouchpoint) &&
+        values.readsSupportedLeaders.includes(OTHER_LEADER_OPTION) &&
+        !value
+          ? "Please specify other school leaders"
+          : null
+      ),
+      readsLeaderVisitDuration: whenNotCancelled((value, values) =>
+        readsShown(values) && readsShowsLeaderBlock(values.readsTouchpoint) && !value
+          ? PICK_ONE
+          : null
+      ),
+      readsLeaderCapacityFocus: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsLeaderBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      readsSupportedDistrictLeaders: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsDistrictBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      readsSupportedDistrictLeadersOther: whenNotCancelled((value, values) =>
+        readsShown(values) &&
+        readsShowsDistrictBlock(values.readsTouchpoint) &&
+        values.readsSupportedDistrictLeaders.includes(OTHER_LEADER_OPTION) &&
+        !value
+          ? "Please specify other district leaders"
+          : null
+      ),
+      readsDistrictSupports: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsDistrictBlock(values.readsTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      mtssPracticesResponses: whenNotCancelled((value: string[], values) =>
+        readsShown(values) &&
+        readsShowsMtssPilot(values.readsTouchpoint, values.district, values.school) &&
+        value.some((r) => !r)
+          ? "Please respond to every MTSS practice statement"
+          : null
+      ),
+
+      // --- NYC Solves ---------------------------------------------------
+      solvesTouchpoint: whenNotCancelled((value, values) =>
+        solvesShown(values) && !value ? "Please select a touchpoint type" : null
+      ),
+      solvesTeacherVisitDuration: whenNotCancelled((value, values) =>
+        solvesShown(values) && solvesShowsTeacherBlock(values.solvesTouchpoint) && !value
+          ? PICK_ONE
+          : null
+      ),
+      solvesSupportedTeacherTypes: whenNotCancelled((value: string[], values) =>
+        solvesShown(values) &&
+        solvesShowsTeacherBlock(values.solvesTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      solvesGradeContentAreas: whenNotCancelled((value: string[], values) =>
+        solvesShown(values) &&
+        solvesShowsTeacherBlock(values.solvesTouchpoint) &&
+        value.length === 0
+          ? PICK_AT_LEAST_ONE
+          : null
+      ),
+      solvesTeacherProtocols: whenNotCancelled((value: string[], values) =>
+        solvesShown(values) &&
+        solvesShowsTeacherBlock(values.solvesTouchpoint) &&
+        value.length === 0
+          ? "Please select at least one protocol"
+          : null
+      ),
+      solvesIntervisitationDBNs: whenNotCancelled((value, values) =>
+        solvesShown(values) &&
+        solvesShowsTeacherBlock(values.solvesTouchpoint) &&
+        values.solvesTeacherProtocols.includes(SOLVES_INTERVISITATION_PROTOCOL) &&
+        !value
+          ? "Please list the school DBNs"
+          : null
+      ),
+      solvesMajorityUsingHQIM: whenNotCancelled((value, values) =>
+        solvesShown(values) && solvesShowsTeacherBlock(values.solvesTouchpoint) && !value
+          ? PICK_YES_NO
+          : null
+      ),
+      solvesHQIMContext: whenNotCancelled((value, values) =>
+        solvesShown(values) &&
+        solvesShowsTeacherBlock(values.solvesTouchpoint) &&
+        values.solvesMajorityUsingHQIM === "No" &&
+        !value
+          ? "Please share additional context"
+          : null
+      ),
+      solvesLeaderSupportDuration: whenNotCancelled((value, values) =>
+        solvesShown(values) && solvesShowsLeaderBlock(values.solvesTouchpoint) && !value
+          ? PICK_ONE
+          : null
+      ),
+      solvesLeaderSupportTrack: whenNotCancelled((value, values) =>
+        solvesShown(values) && solvesShowsLeaderBlock(values.solvesTouchpoint) && !value
+          ? PICK_ONE
+          : null
+      ),
+      solvesAdditionalSupportDuration: whenNotCancelled((value, values) =>
+        solvesShown(values) &&
+        solvesShowsAdditionalSupport(values.solvesTouchpoint) &&
+        !value
+          ? PICK_ONE
+          : null
+      ),
+      solvesAdditionalSupportType: whenNotCancelled((value, values) =>
+        solvesShown(values) &&
+        solvesShowsAdditionalSupport(values.solvesTouchpoint) &&
+        !value
+          ? PICK_ONE
           : null
       ),
 

--- a/app/domains/coach-log/model.ts
+++ b/app/domains/coach-log/model.ts
@@ -70,6 +70,44 @@ export type CoachLogSubmission = {
   ecTeacherStrategies: string[];
   ecLeaderCapacityFocus: string[];
 
+  // NYC Reads coach
+  readsIsPLSession: YesNo | "";
+  readsScheduleProvided: YesNo | "";
+  readsHighImpactActivities: YesNo | "";
+  readsTouchpoint: string;
+  readsIsMultiSchool: YesNo | "";
+  readsMultiSchoolDBN: string;
+  readsVisitDuration: string;
+  readsSupportedTeacherTypes: string[];
+  readsGradeBands: string[];
+  readsTeacherStrategies: string[];
+  readsMTSSFocus: YesNo | "";
+  readsMajorityUsingHQIM: YesNo | "";
+  readsHQIMContext: string;
+  readsSupportedLeaders: string[];
+  readsSupportedLeadersOther: string;
+  readsLeaderVisitDuration: string;
+  readsLeaderCapacityFocus: string[];
+  readsSupportedDistrictLeaders: string[];
+  readsSupportedDistrictLeadersOther: string;
+  readsDistrictSupports: string[];
+  mtssPracticesResponses: string[];
+  mtssAdditionalContext: string;
+
+  // NYC Solves coach
+  solvesTouchpoint: string;
+  solvesTeacherVisitDuration: string;
+  solvesSupportedTeacherTypes: string[];
+  solvesGradeContentAreas: string[];
+  solvesTeacherProtocols: string[];
+  solvesIntervisitationDBNs: string;
+  solvesMajorityUsingHQIM: YesNo | "";
+  solvesHQIMContext: string;
+  solvesLeaderSupportDuration: string;
+  solvesLeaderSupportTrack: string;
+  solvesAdditionalSupportDuration: string;
+  solvesAdditionalSupportType: string;
+
   // Cancellation
   canceled: YesNo | "";
   cancelReason: string;

--- a/app/routes/api.coach-log.submit.tsx
+++ b/app/routes/api.coach-log.submit.tsx
@@ -1,6 +1,19 @@
 import type { ActionFunctionArgs } from "@vercel/remix";
 import type { CoachLogSubmission } from "~/domains/coach-log/model";
 import { insertMondayData } from "~/domains/utils";
+import {
+  readsShowsDistrictBlock,
+  readsShowsLeaderBlock,
+  readsShowsTeacherBlock,
+  SOLVES_INTERVISITATION_PROTOCOL,
+  solvesShowsAdditionalSupport,
+  solvesShowsLeaderBlock,
+  solvesShowsTeacherBlock,
+} from "~/components/coach-log/questions/nyc/constants";
+
+// Joins a multi-select array into the comma-separated string the Monday text
+// columns expect (matching the legacy form's serialization).
+const csv = (values: string[] | undefined) => (values ?? []).join(", ");
 
 // A real session date is YYYY-MM-DD; the "N/A" sentinel must not be written to a
 // Monday date column.
@@ -27,6 +40,40 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     ecTouchpoint,
     ecTeacherStrategies,
     ecLeaderCapacityFocus,
+    readsIsPLSession,
+    readsScheduleProvided,
+    readsHighImpactActivities,
+    readsTouchpoint,
+    readsIsMultiSchool,
+    readsMultiSchoolDBN,
+    readsVisitDuration,
+    readsSupportedTeacherTypes,
+    readsGradeBands,
+    readsTeacherStrategies,
+    readsMTSSFocus,
+    readsMajorityUsingHQIM,
+    readsHQIMContext,
+    readsSupportedLeaders,
+    readsSupportedLeadersOther,
+    readsLeaderVisitDuration,
+    readsLeaderCapacityFocus,
+    readsSupportedDistrictLeaders,
+    readsSupportedDistrictLeadersOther,
+    readsDistrictSupports,
+    mtssPracticesResponses,
+    mtssAdditionalContext,
+    solvesTouchpoint,
+    solvesTeacherVisitDuration,
+    solvesSupportedTeacherTypes,
+    solvesGradeContentAreas,
+    solvesTeacherProtocols,
+    solvesIntervisitationDBNs,
+    solvesMajorityUsingHQIM,
+    solvesHQIMContext,
+    solvesLeaderSupportDuration,
+    solvesLeaderSupportTrack,
+    solvesAdditionalSupportDuration,
+    solvesAdditionalSupportType,
     canceled,
     cancelReason,
     cancelReasonOther,
@@ -68,6 +115,98 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       parentColumns.text_mktgaftm = ecTeacherStrategies.join(", "); // Teacher strategies
     if (ecLeaderCapacityFocus?.length)
       parentColumns.text_mktggp36 = ecLeaderCapacityFocus.join(", "); // Leader capacity focus
+
+    // NYC Reads (the client only sends these for a Reads coach). Each touchpoint
+    // block is gated again here so stale hidden values are never written.
+    if (readsTouchpoint) {
+      if (readsIsPLSession) parentColumns.text_mkv0r1t = readsIsPLSession;
+      if (readsScheduleProvided) parentColumns.text_mm1erdxw = readsScheduleProvided;
+      if (readsHighImpactActivities)
+        parentColumns.text_mm1ec7kg = readsHighImpactActivities;
+      parentColumns.text_mktgtahx = readsTouchpoint;
+
+      if (readsShowsTeacherBlock(readsTouchpoint)) {
+        if (readsIsMultiSchool) parentColumns.text_mktgedch = readsIsMultiSchool;
+        if (readsIsMultiSchool === "Yes" && readsMultiSchoolDBN)
+          parentColumns.text_mkvmnx9g = readsMultiSchoolDBN;
+        if (readsVisitDuration) parentColumns.text_mktgt2ah = readsVisitDuration;
+        if (readsSupportedTeacherTypes?.length)
+          parentColumns.text_mktgnqcx = csv(readsSupportedTeacherTypes);
+        if (readsGradeBands?.length)
+          parentColumns.text_mktgz9wm = csv(readsGradeBands);
+        if (readsTeacherStrategies?.length)
+          parentColumns.text_mktgaftm = csv(readsTeacherStrategies);
+        if (readsMTSSFocus) parentColumns.text_mkv0fs1n = readsMTSSFocus;
+        if (readsMajorityUsingHQIM)
+          parentColumns.text_mkv0w2eq = readsMajorityUsingHQIM;
+        if (readsMajorityUsingHQIM === "No" && readsHQIMContext)
+          parentColumns.text_mkxspvf5 = readsHQIMContext;
+      }
+
+      if (readsShowsLeaderBlock(readsTouchpoint)) {
+        if (readsSupportedLeaders?.length)
+          parentColumns.text_mktg8pn8 = csv(readsSupportedLeaders);
+        if (readsSupportedLeadersOther)
+          parentColumns.text_mktgph5d = readsSupportedLeadersOther;
+        if (readsLeaderVisitDuration)
+          parentColumns.text_mktggbxt = readsLeaderVisitDuration;
+        if (readsLeaderCapacityFocus?.length)
+          parentColumns.text_mktggp36 = csv(readsLeaderCapacityFocus);
+      }
+
+      if (readsShowsDistrictBlock(readsTouchpoint)) {
+        if (readsSupportedDistrictLeaders?.length)
+          parentColumns.text_mktgzc4s = csv(readsSupportedDistrictLeaders);
+        if (readsSupportedDistrictLeadersOther)
+          parentColumns.text_mktgexpt = readsSupportedDistrictLeadersOther;
+        if (readsDistrictSupports?.length)
+          parentColumns.text_mktg32xj = csv(readsDistrictSupports);
+      }
+
+      if (mtssPracticesResponses?.some((r) => r))
+        parentColumns.long_text_mkxsd1qs = mtssPracticesResponses.join(" | ");
+      if (mtssAdditionalContext)
+        parentColumns.long_text_mkxsxkdh = mtssAdditionalContext;
+    }
+
+    // NYC Solves (client only sends these for a Solves coach).
+    if (solvesTouchpoint) {
+      parentColumns.text_mkthbvw5 = solvesTouchpoint;
+
+      if (solvesShowsTeacherBlock(solvesTouchpoint)) {
+        if (solvesTeacherVisitDuration)
+          parentColumns.text_mkthtzhb = solvesTeacherVisitDuration;
+        if (solvesSupportedTeacherTypes?.length)
+          parentColumns.text_mkthqes0 = csv(solvesSupportedTeacherTypes);
+        if (solvesGradeContentAreas?.length)
+          parentColumns.text_mkth9zzf = csv(solvesGradeContentAreas);
+        if (solvesTeacherProtocols?.length)
+          parentColumns.text_mkthqrth = csv(solvesTeacherProtocols);
+        if (
+          solvesTeacherProtocols?.includes(SOLVES_INTERVISITATION_PROTOCOL) &&
+          solvesIntervisitationDBNs
+        )
+          parentColumns.text_mkth5zrt = solvesIntervisitationDBNs;
+        if (solvesMajorityUsingHQIM)
+          parentColumns.text_mkttj6kq = solvesMajorityUsingHQIM;
+        if (solvesMajorityUsingHQIM === "No" && solvesHQIMContext)
+          parentColumns.text_mkxsvgng = solvesHQIMContext;
+      }
+
+      if (solvesShowsLeaderBlock(solvesTouchpoint)) {
+        if (solvesLeaderSupportDuration)
+          parentColumns.text_mkth7jye = solvesLeaderSupportDuration;
+        if (solvesLeaderSupportTrack)
+          parentColumns.text_mkthjyrx = solvesLeaderSupportTrack;
+      }
+
+      if (solvesShowsAdditionalSupport(solvesTouchpoint)) {
+        if (solvesAdditionalSupportDuration)
+          parentColumns.text_mkth5kcn = solvesAdditionalSupportDuration;
+        if (solvesAdditionalSupportType)
+          parentColumns.text_mkthwj61 = solvesAdditionalSupportType;
+      }
+    }
 
     if (canceled === "Yes") {
       parentColumns.text51__1 = cancelReason; // Why session did not take place


### PR DESCRIPTION
Closes #120 — part of the Coach Log form revamp.

Ports the two large NYC coach-type question sets from the legacy form, rebuilt as clean, modular components. Rendered in the not-cancelled activities block, gated on an NYC district + coach type.

## NYC Reads (Reads Coach)
- Professional Learning Session question — **Yes auto-answers 1:1 & group coaching "No"**.
- Capacity-builder questions for **D9/D75**.
- Touchpoint type → teacher / school-leader / district-support sub-blocks (with conditional multi-school DBN, HQIM context, and "Other" specify fields).
- **MTSS Pilot Schools** block (7 rated practices + optional context), gated to pilot school codes in D9/D11/D12/D13.
- Leader-visit duration changed to **1/2/3/4** (FY27).

## NYC Solves (Solves Coach/D75 Math Coach)
- Touchpoint type → teacher / leader / additional-support sub-blocks.
- Protocols capped at 3; conditional intervisitation-DBN and HQIM-context fields.

## Notes
- JES End-of-Year reflections dropped; standalone legacy duration/touchpoint fields skipped.
- `questions/nyc/` holds focused sub-blocks + a `QuestionField` wrapper; options + predicates in `questions/nyc/constants.ts`.
- Submission mapping extracted to pure `build-submission.ts`; validation and submit route both re-gate by touchpoint block, so hidden values are never submitted.
- All Monday column IDs unchanged from legacy (verified on the board).
- Typecheck + build pass.

> Base is `feat/coach-log-ela-early-childhood` (the in-flight EC branch). Retarget down the chain to `main` as the earlier branches merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)