### PR TITLE
feat(coach-log): prevent duplicate logs + require a real session date

### DIFF
--- a/app/components/coach-log/build-submission.ts
+++ b/app/components/coach-log/build-submission.ts
@@ -6,7 +6,7 @@ import {
   shouldShowSolves,
   shouldShowSubSchool,
 } from "./constants";
-import type { CoachLogValues } from "./use-coach-log-form";
+import type { CoachLogValues } from "./hooks/use-coach-log-form";
 
 type Coach = { name: string; mondayProfileId: string };
 

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -1,4 +1,4 @@
-import { Button, Loader, Notification, Tabs } from "@mantine/core";
+import { Button, Loader, Notification, Tabs, Text } from "@mantine/core";
 import { IconAlertTriangle, IconCheck, IconX } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -27,11 +27,12 @@ import { NycCoachTypeQuestion } from "./questions/nyc-coach-type-question";
 import { OneOnOneCoachingQuestion } from "./questions/one-on-one-coaching-question";
 import { SessionDateQuestion } from "./questions/session-date-question";
 import { SubSchoolQuestion } from "./questions/sub-school-question";
+import { useDuplicateCheck } from "./hooks/use-duplicate-check";
 import {
   EMPTY_COACHEE_ROW,
   useCoachLogForm,
   type CoachLogValues,
-} from "./use-coach-log-form";
+} from "./hooks/use-coach-log-form";
 
 type Props = {
   districts: DistrictWithSchools[];
@@ -59,7 +60,23 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const [failedCoachees, setFailedCoachees] = useState<string[]>([]);
   const [showErrorBanner, setShowErrorBanner] = useState(false);
 
-  const { district, school, nycCoachType, canceled } = form.values;
+  const { district, school, nycCoachType, canceled, sessionDate } =
+    form.values;
+
+  // One log per coach + district + school + date — checked as soon as those are
+  // chosen so the coach is warned before filling out the form.
+  const {
+    duplicateExists,
+    checking: checkingDuplicate,
+    setDuplicateExists,
+  } = useDuplicateCheck({
+    coachMondayId: mondayProfile?.mondayProfileId ?? "",
+    coachName,
+    district,
+    school,
+    sessionDate,
+  });
+
   const showNycCoachType = isNycCoachTypeDistrict(district);
   const showSubSchool = shouldShowSubSchool(district, nycCoachType);
   const showEarlyChildhood = shouldShowEarlyChildhood(district, nycCoachType);
@@ -170,15 +187,6 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     };
   }, [district, coachName]);
 
-  // No scheduled dates for this coach + district -> auto-select the "N/A"
-  // sentinel so the required date field can still be submitted.
-  useEffect(() => {
-    if (district && !loadingSessionDates && sessionDateOptions.length === 0) {
-      form.setFieldValue("sessionDate", "N/A");
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [district, loadingSessionDates, sessionDateOptions]);
-
   const handleSubmit = async (values: CoachLogValues) => {
     if (!mondayProfile?.name) {
       console.error("Please log in first");
@@ -210,6 +218,10 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
         };
         setFailedCoachees(body.failedCoachees ?? []);
         setIsSuccessful(true);
+      } else if (response.status === 409) {
+        // A log for this coach + district + school + date already exists.
+        setDuplicateExists(true);
+        setIsSuccessful(null);
       } else {
         setIsSuccessful(response.ok);
       }
@@ -265,6 +277,16 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
                 loading={loadingSessionDates}
               />
 
+              {checkingDuplicate && (
+                <div className="flex items-center gap-2">
+                  <Loader size="sm" />
+                  <Text size="sm" c="white">
+                    Checking whether a log already exists for this school and
+                    date...
+                  </Text>
+                </div>
+              )}
+
               <CancellationQuestion form={form} />
 
               {showActivities && (
@@ -290,7 +312,23 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
                 </>
               )}
 
-              {!isSubmitting && <Button type="submit">Submit</Button>}
+              {duplicateExists && (
+                <Notification
+                  icon={<IconAlertTriangle size={20} />}
+                  color="yellow"
+                  title="A coach log already exists for this school on this date."
+                  withCloseButton={false}
+                >
+                  Only one log can be submitted per school per day. To make
+                  changes, update the existing log or contact the team.
+                </Notification>
+              )}
+
+              {!isSubmitting && (
+                <Button type="submit" disabled={duplicateExists}>
+                  Submit
+                </Button>
+              )}
               {isSubmitting && (
                 <Loader size={30} color="rgba(255, 255, 255, 1)" />
               )}

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -7,6 +7,7 @@ import {
   type SessionDateOption,
   type SubSchoolMap,
 } from "~/domains/coach-log/model";
+import { cn } from "~/utils/utils";
 import { useSession } from "../auth/hooks/useSession";
 import { buildCoachLogSubmission } from "./build-submission";
 import { ParticipantRosterForm } from "./participant-roster-form";
@@ -68,6 +69,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const {
     duplicateExists,
     checking: checkingDuplicate,
+    checkError: duplicateCheckError,
     setDuplicateExists,
   } = useDuplicateCheck({
     coachMondayId: mondayProfile?.mondayProfileId ?? "",
@@ -76,6 +78,11 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     school,
     sessionDate,
   });
+
+  // While the check is running or a duplicate exists, the activity questions are
+  // locked so the coach can't fill out a log that won't submit (they can still
+  // change district/school/date above to resolve it).
+  const lockActivities = checkingDuplicate || duplicateExists;
 
   const showNycCoachType = isNycCoachTypeDistrict(district);
   const showSubSchool = shouldShowSubSchool(district, nycCoachType);
@@ -287,30 +294,51 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
                 </div>
               )}
 
-              <CancellationQuestion form={form} />
-
-              {showActivities && (
-                <>
-                  <OneOnOneCoachingQuestion
-                    form={form}
-                    coacheeOptions={coacheeOptions}
-                    loadingCoachees={loadingCoachees}
-                  />
-                  <GroupCoachingQuestion
-                    form={form}
-                    coacheeOptions={coacheeOptions}
-                  />
-                  {showEarlyChildhood && <EarlyChildhoodQuestion form={form} />}
-                  {showReads && (
-                    <ReadsQuestion
-                      form={form}
-                      district={district}
-                      school={school}
-                    />
-                  )}
-                  {showSolves && <SolvesQuestion form={form} />}
-                </>
+              {duplicateCheckError && (
+                <Notification
+                  icon={<IconX size={20} />}
+                  color="red"
+                  title="We couldn't verify whether a log already exists for this date."
+                  withCloseButton={false}
+                >
+                  To avoid creating a duplicate submission, we strongly recommend
+                  reaching out to the technology team before submitting this log.
+                </Notification>
               )}
+
+              <fieldset
+                disabled={lockActivities}
+                className={cn("flex flex-col gap-4 m-0 p-0 border-0 min-w-0", {
+                  "opacity-60 pointer-events-none": lockActivities,
+                })}
+              >
+                <CancellationQuestion form={form} />
+
+                {showActivities && (
+                  <>
+                    <OneOnOneCoachingQuestion
+                      form={form}
+                      coacheeOptions={coacheeOptions}
+                      loadingCoachees={loadingCoachees}
+                    />
+                    <GroupCoachingQuestion
+                      form={form}
+                      coacheeOptions={coacheeOptions}
+                    />
+                    {showEarlyChildhood && (
+                      <EarlyChildhoodQuestion form={form} />
+                    )}
+                    {showReads && (
+                      <ReadsQuestion
+                        form={form}
+                        district={district}
+                        school={school}
+                      />
+                    )}
+                    {showSolves && <SolvesQuestion form={form} />}
+                  </>
+                )}
+              </fieldset>
 
               {duplicateExists && (
                 <Notification
@@ -320,12 +348,15 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
                   withCloseButton={false}
                 >
                   Only one log can be submitted per school per day. To make
-                  changes, update the existing log or contact the team.
+                  changes, contact the team.
                 </Notification>
               )}
 
               {!isSubmitting && (
-                <Button type="submit" disabled={duplicateExists}>
+                <Button
+                  type="submit"
+                  disabled={duplicateExists || checkingDuplicate}
+                >
                   Submit
                 </Button>
               )}

--- a/app/components/coach-log/hooks/use-coach-log-form.ts
+++ b/app/components/coach-log/hooks/use-coach-log-form.ts
@@ -8,7 +8,7 @@ import {
   shouldShowEarlyChildhood,
   shouldShowReads,
   shouldShowSolves,
-} from "./constants";
+} from "../constants";
 import {
   isReadsCapacityBuilderDistrict,
   OTHER_LEADER_OPTION,
@@ -20,7 +20,7 @@ import {
   solvesShowsAdditionalSupport,
   solvesShowsLeaderBlock,
   solvesShowsTeacherBlock,
-} from "./questions/nyc/constants";
+} from "../questions/nyc/constants";
 
 /** Single source of truth for every Coach Log field. */
 export type CoachLogValues = {

--- a/app/components/coach-log/hooks/use-duplicate-check.ts
+++ b/app/components/coach-log/hooks/use-duplicate-check.ts
@@ -7,25 +7,30 @@ import type { CoachLogIdentity } from "~/domains/coach-log/model";
  * the `/api/coach-log/exists` endpoint, and exposes:
  *  - `duplicateExists`: true when a matching log was found
  *  - `checking`: true while the check is in flight
+ *  - `checkError`: true when the check couldn't complete (so the form can warn
+ *    the coach instead of silently assuming "no duplicate")
  *  - `setDuplicateExists`: so the submit handler can flip it on a server 409
  *
- * The check is skipped (and `duplicateExists` reset) until all four fields are
- * present. The authoritative guard still lives in the submit route.
+ * The check is skipped (and state reset) until all four fields are present. The
+ * authoritative guard still lives in the submit route.
  */
 export function useDuplicateCheck(query: CoachLogIdentity) {
   const { coachMondayId, coachName, district, school, sessionDate } = query;
   const [duplicateExists, setDuplicateExists] = useState(false);
   const [checking, setChecking] = useState(false);
+  const [checkError, setCheckError] = useState(false);
 
   useEffect(() => {
     if (!district || !school || !sessionDate) {
       setDuplicateExists(false);
       setChecking(false);
+      setCheckError(false);
       return;
     }
 
     let cancelled = false;
     setChecking(true);
+    setCheckError(false);
     fetch("/api/coach-log/exists", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -39,10 +44,20 @@ export function useDuplicateCheck(query: CoachLogIdentity) {
     })
       .then((r) => r.json())
       .then((data) => {
-        if (!cancelled) setDuplicateExists(!!data.exists);
+        if (cancelled) return;
+        if (data.error) {
+          setCheckError(true);
+          setDuplicateExists(false);
+        } else {
+          setCheckError(false);
+          setDuplicateExists(!!data.exists);
+        }
       })
       .catch(() => {
-        if (!cancelled) setDuplicateExists(false);
+        if (!cancelled) {
+          setCheckError(true);
+          setDuplicateExists(false);
+        }
       })
       .finally(() => {
         if (!cancelled) setChecking(false);
@@ -53,5 +68,5 @@ export function useDuplicateCheck(query: CoachLogIdentity) {
     };
   }, [coachMondayId, coachName, district, school, sessionDate]);
 
-  return { duplicateExists, checking, setDuplicateExists };
+  return { duplicateExists, checking, checkError, setDuplicateExists };
 }

--- a/app/components/coach-log/hooks/use-duplicate-check.ts
+++ b/app/components/coach-log/hooks/use-duplicate-check.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import type { CoachLogIdentity } from "~/domains/coach-log/model";
+
+/**
+ * Checks whether a coach log already exists for this coach + district + school +
+ * date (the one-log-per-day rule). Re-runs whenever any of those change, calling
+ * the `/api/coach-log/exists` endpoint, and exposes:
+ *  - `duplicateExists`: true when a matching log was found
+ *  - `checking`: true while the check is in flight
+ *  - `setDuplicateExists`: so the submit handler can flip it on a server 409
+ *
+ * The check is skipped (and `duplicateExists` reset) until all four fields are
+ * present. The authoritative guard still lives in the submit route.
+ */
+export function useDuplicateCheck(query: CoachLogIdentity) {
+  const { coachMondayId, coachName, district, school, sessionDate } = query;
+  const [duplicateExists, setDuplicateExists] = useState(false);
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    if (!district || !school || !sessionDate) {
+      setDuplicateExists(false);
+      setChecking(false);
+      return;
+    }
+
+    let cancelled = false;
+    setChecking(true);
+    fetch("/api/coach-log/exists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        coachMondayId,
+        coachName,
+        district,
+        school,
+        sessionDate,
+      }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled) setDuplicateExists(!!data.exists);
+      })
+      .catch(() => {
+        if (!cancelled) setDuplicateExists(false);
+      })
+      .finally(() => {
+        if (!cancelled) setChecking(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [coachMondayId, coachName, district, school, sessionDate]);
+
+  return { duplicateExists, checking, setDuplicateExists };
+}

--- a/app/components/coach-log/questions/cancellation-question.tsx
+++ b/app/components/coach-log/questions/cancellation-question.tsx
@@ -4,7 +4,7 @@ import {
   CANCELLATION_REASON_OPTIONS,
   YES_NO_OPTIONS,
 } from "../constants";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 type Props = {
   form: CoachLogForm;

--- a/app/components/coach-log/questions/district-school-question.tsx
+++ b/app/components/coach-log/questions/district-school-question.tsx
@@ -1,7 +1,7 @@
 import { Select } from "@mantine/core";
 import { useMemo } from "react";
 import type { DistrictWithSchools } from "~/domains/coach-log/model";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 type Props = {
   form: CoachLogForm;

--- a/app/components/coach-log/questions/early-childhood-question.tsx
+++ b/app/components/coach-log/questions/early-childhood-question.tsx
@@ -7,7 +7,7 @@ import {
   ecShowsLeaderCapacity,
   ecShowsTeacherStrategies,
 } from "../constants";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 const JES_GLOSSARY_URL =
   "https://docs.google.com/document/d/1WiGwohRHYmXeJztoUI0cplQ3g5inr8LjjyDChNQrDpY/edit?tab=t.0#heading=h.cslg194210x2";

--- a/app/components/coach-log/questions/group-coaching-question.tsx
+++ b/app/components/coach-log/questions/group-coaching-question.tsx
@@ -1,6 +1,6 @@
 import { MultiSelect, Select, Textarea } from "@mantine/core";
 import { DURATION_OPTIONS, ROLE_OPTIONS, YES_NO_OPTIONS } from "../constants";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 type Props = {
   form: CoachLogForm;

--- a/app/components/coach-log/questions/nyc-coach-type-question.tsx
+++ b/app/components/coach-log/questions/nyc-coach-type-question.tsx
@@ -1,6 +1,6 @@
 import { Select } from "@mantine/core";
 import { NYC_COACH_TYPE_OPTIONS } from "../constants";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 type Props = {
   form: CoachLogForm;

--- a/app/components/coach-log/questions/nyc/mtss-pilot-question.tsx
+++ b/app/components/coach-log/questions/nyc/mtss-pilot-question.tsx
@@ -1,5 +1,5 @@
 import { Select, Text, Textarea } from "@mantine/core";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import { MTSS_PRACTICE_STATEMENTS, MTSS_RESPONSE_OPTIONS } from "./constants";
 import { QuestionField } from "./field";
 

--- a/app/components/coach-log/questions/nyc/reads-district-support.tsx
+++ b/app/components/coach-log/questions/nyc/reads-district-support.tsx
@@ -1,5 +1,5 @@
 import { MultiSelect, TextInput } from "@mantine/core";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   DISTRICT_SUPPORT_OPTIONS,
   OTHER_LEADER_OPTION,

--- a/app/components/coach-log/questions/nyc/reads-leader-support.tsx
+++ b/app/components/coach-log/questions/nyc/reads-leader-support.tsx
@@ -1,5 +1,5 @@
 import { MultiSelect, Select, TextInput } from "@mantine/core";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   JES_GLOSSARY_URL,
   LEADER_CAPACITY_FOCUS_OPTIONS,

--- a/app/components/coach-log/questions/nyc/reads-question.tsx
+++ b/app/components/coach-log/questions/nyc/reads-question.tsx
@@ -1,7 +1,7 @@
 import { Select } from "@mantine/core";
 import type { YesNo } from "~/domains/coach-log/model";
 import { YES_NO_OPTIONS } from "../../constants";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   isReadsCapacityBuilderDistrict,
   READS_TOUCHPOINT_OPTIONS,

--- a/app/components/coach-log/questions/nyc/reads-teacher-support.tsx
+++ b/app/components/coach-log/questions/nyc/reads-teacher-support.tsx
@@ -1,6 +1,6 @@
 import { MultiSelect, Select, Textarea, TextInput } from "@mantine/core";
 import { YES_NO_OPTIONS } from "../../constants";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   MAX_TEACHER_STRATEGIES,
   READS_GRADE_BAND_OPTIONS,

--- a/app/components/coach-log/questions/nyc/solves-additional-support.tsx
+++ b/app/components/coach-log/questions/nyc/solves-additional-support.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@mantine/core";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   SOLVES_ADDITIONAL_SUPPORT_DURATION_OPTIONS,
   SOLVES_ADDITIONAL_SUPPORT_TYPE_OPTIONS,

--- a/app/components/coach-log/questions/nyc/solves-leader-support.tsx
+++ b/app/components/coach-log/questions/nyc/solves-leader-support.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@mantine/core";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   SOLVES_LEADER_SUPPORT_DURATION_OPTIONS,
   SOLVES_LEADER_SUPPORT_TRACK_OPTIONS,

--- a/app/components/coach-log/questions/nyc/solves-question.tsx
+++ b/app/components/coach-log/questions/nyc/solves-question.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@mantine/core";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   SOLVES_TOUCHPOINT_OPTIONS,
   solvesShowsAdditionalSupport,

--- a/app/components/coach-log/questions/nyc/solves-teacher-support.tsx
+++ b/app/components/coach-log/questions/nyc/solves-teacher-support.tsx
@@ -1,6 +1,6 @@
 import { MultiSelect, Select, Textarea, TextInput } from "@mantine/core";
 import { YES_NO_OPTIONS } from "../../constants";
-import type { CoachLogForm } from "../../use-coach-log-form";
+import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
   JES_GLOSSARY_URL,
   MAX_SOLVES_PROTOCOLS,

--- a/app/components/coach-log/questions/one-on-one-coaching-question.tsx
+++ b/app/components/coach-log/questions/one-on-one-coaching-question.tsx
@@ -2,7 +2,7 @@ import { Button, Loader, Select, Text } from "@mantine/core";
 import { IconX } from "@tabler/icons-react";
 import { cn } from "~/utils/utils";
 import { DURATION_OPTIONS, ROLE_OPTIONS, YES_NO_OPTIONS } from "../constants";
-import { EMPTY_COACHEE_ROW, type CoachLogForm } from "../use-coach-log-form";
+import { EMPTY_COACHEE_ROW, type CoachLogForm } from "../hooks/use-coach-log-form";
 
 function gridClass(canDelete: boolean) {
   return cn("grid gap-4 grid-cols-[2fr_1.5fr_1fr]", {

--- a/app/components/coach-log/questions/session-date-question.tsx
+++ b/app/components/coach-log/questions/session-date-question.tsx
@@ -1,6 +1,6 @@
 import { Loader, Select, Text } from "@mantine/core";
 import type { SessionDateOption } from "~/domains/coach-log/model";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 type Props = {
   form: CoachLogForm;
@@ -11,23 +11,21 @@ type Props = {
 /**
  * Date-of-session selector. Options come from the coaching PL calendar, scoped
  * to the logged-in coach + the selected district (fetched once a district is
- * chosen). Real values are YYYY-MM-DD so they map straight into the Monday date
- * column on submit. When the calendar has no dates for the coach + district, an
- * "N/A" option is offered (and auto-selected by the form) so the required field
- * can still be submitted.
+ * chosen). Values are YYYY-MM-DD so they map straight into the Monday date
+ * column on submit. When the calendar has no dates for the coach + district, the
+ * field is left blank (no option) so the required date can't be submitted — the
+ * coach is prompted to contact the team to confirm the date first.
  */
 export const SessionDateQuestion = ({ form, options, loading }: Props) => {
   const district = form.values.district;
   const noDatesFound = !!district && !loading && options.length === 0;
 
-  const data: SessionDateOption[] = noDatesFound
-    ? [{ value: "N/A", label: "N/A — no scheduled dates found" }]
-    : options;
-
   const placeholder = !district
     ? "Select a district first"
     : loading
     ? "Loading dates..."
+    : noDatesFound
+    ? "No scheduled dates found"
     : "Select a date";
 
   return (
@@ -40,12 +38,18 @@ export const SessionDateQuestion = ({ form, options, loading }: Props) => {
       </Text>
       <Select
         placeholder={placeholder}
-        data={data}
+        data={options}
         searchable
         disabled={!district || loading}
         rightSection={loading ? <Loader size="xs" /> : undefined}
         {...form.getInputProps("sessionDate")}
       />
+      {noDatesFound && (
+        <Text size="sm" c="yellow">
+          No scheduled dates were found for you in this district. Please contact
+          the team to confirm the date before submitting this log.
+        </Text>
+      )}
     </div>
   );
 };

--- a/app/components/coach-log/questions/sub-school-question.tsx
+++ b/app/components/coach-log/questions/sub-school-question.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@mantine/core";
-import type { CoachLogForm } from "../use-coach-log-form";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
 
 type Props = {
   form: CoachLogForm;

--- a/app/domains/coach-log/model.ts
+++ b/app/domains/coach-log/model.ts
@@ -42,6 +42,19 @@ export type SessionDateOption = {
   label: string;
 };
 
+/**
+ * The fields that uniquely identify a coach log for the duplicate check: one log
+ * per coach + district + school + date. `coachMondayId` is preferred for the
+ * coach match; `coachName` (the item name) is the fallback.
+ */
+export type CoachLogIdentity = {
+  coachMondayId: string;
+  coachName: string;
+  district: string;
+  school: string;
+  sessionDate: string;
+};
+
 /** One 1:1 coaching entry. Each row becomes a Monday subitem on submission. */
 export type CoacheeRow = {
   coacheeName: string;

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -3,7 +3,7 @@ import { google } from "googleapis";
 import { asyncBufferFromFile, parquetReadObjects } from "hyparquet";
 import { Errorable } from "~/utils/errorable";
 import { fetchMondayData } from "~/domains/utils";
-import { DistrictWithSchools, SubSchoolRow } from "./model";
+import { CoachLogIdentity, DistrictWithSchools, SubSchoolRow } from "./model";
 
 // Coach-log reference data lives in one Google Sheet with several tabs. Tabs are
 // identified by gid (sheetId), which we resolve to a tab title before reading
@@ -23,6 +23,12 @@ const SHEETS_READONLY_SCOPE =
 // short_text66 = School, text_mkvxqh6c = Updated Participant Name (falls back to
 // text_mktbkbvy = Participant Name).
 const COACHEE_ROSTER_BOARD_ID = 18416567790;
+
+// Coach Log submission board ("IN DEV: FY27 Coaching Log"). Parent-item columns
+// used for the one-log-per coach/district/school/date duplicate check:
+//   text88__1 = District, text5__1 = School, date__1 = Date, people__1 = Coach
+//   (item name is the coach name). Shared with the submit route.
+export const COACH_LOG_BOARD_ID = 18416482214;
 
 // Interim session-date source: a parquet export of the coaching PL calendar,
 // committed at the repo root. Replaced later by the AWS-backed source. Read from
@@ -101,6 +107,7 @@ export interface CoachLogRepository {
     coachName: string,
     district: string
   ): Promise<Errorable<string[]>>;
+  hasExistingLog(query: CoachLogIdentity): Promise<Errorable<boolean>>;
 }
 
 export function coachLogRepository(): CoachLogRepository {
@@ -250,6 +257,100 @@ export function coachLogRepository(): CoachLogRepository {
           data: null,
           error: new Error("fetchSessionDates() went wrong"),
         };
+      }
+    },
+
+    // True if a coach log already exists for this coach + district + school +
+    // date (one-log-per-day rule; cancelled logs count). Narrows the board to
+    // the district + school via Monday filters, then matches coach + date
+    // exactly in JS (the coach matches on the people column id, falling back to
+    // the item name). Returns false when there's no date to dedupe on.
+    hasExistingLog: async (query: CoachLogIdentity) => {
+      try {
+        const date = query.sessionDate.trim();
+        if (!date) return { data: false, error: null };
+
+        const district = normalize(query.district);
+        const school = normalize(query.school);
+        const coachId = query.coachMondayId.trim();
+        const coachName = normalize(query.coachName);
+
+        // Escape values interpolated into the GraphQL rule strings.
+        const esc = (v: string) =>
+          v.trim().replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+        // Filter on the board server-side by district + school + date (exact)
+        // and, when we have one, the coach's Monday profile id. People columns
+        // filter by id only via the "person-<id>" form with any_of (name/raw-id
+        // forms don't match on this board). The result set is 0–1 items; every
+        // field is still verified exactly in JS below.
+        const ruleParts = [
+          `{column_id: "text88__1", operator: contains_text, compare_value: "${esc(query.district)}"}`,
+          `{column_id: "text5__1", operator: contains_text, compare_value: "${esc(query.school)}"}`,
+          `{column_id: "date__1", operator: any_of, compare_value: ["EXACT", "${esc(date)}"]}`,
+        ];
+        if (coachId) {
+          ruleParts.push(
+            `{column_id: "people__1", operator: any_of, compare_value: ["person-${esc(coachId)}"]}`
+          );
+        }
+        const rules = `[${ruleParts.join(", ")}]`;
+
+        const columnIds = `["text88__1","text5__1","date__1","people__1"]`;
+        const buildQuery = (cursor: string | null) =>
+          cursor
+            ? `{ next_items_page(limit: 500, cursor: "${cursor}") { cursor items { name column_values(ids:${columnIds}) { id text value } } } }`
+            : `{ boards(ids: ${COACH_LOG_BOARD_ID}) { items_page(limit: 500, query_params: {rules: ${rules}}) { cursor items { name column_values(ids:${columnIds}) { id text value } } } } }`;
+
+        const matchesItem = (item: any): boolean => {
+          const col = (id: string) =>
+            item.column_values.find((c: any) => c.id === id);
+          let itemDate = "";
+          try {
+            itemDate = JSON.parse(col("date__1")?.value || "null")?.date ?? "";
+          } catch {
+            itemDate = "";
+          }
+          // Exact people-column ids (e.g. ["31288444"]) for a precise match
+          // against the logged-in coach's Monday profile id.
+          let peopleIds: string[] = [];
+          try {
+            const parsed = JSON.parse(col("people__1")?.value || "null");
+            peopleIds = (parsed?.personsAndTeams ?? []).map((p: any) =>
+              String(p.id)
+            );
+          } catch {
+            peopleIds = [];
+          }
+
+          const districtOk = normalize(col("text88__1")?.text) === district;
+          const schoolOk = normalize(col("text5__1")?.text) === school;
+          const dateOk = itemDate.trim() === date;
+          // Prefer matching by Monday profile id; fall back to the item name
+          // (the coach name) only when no id is available.
+          const coachOk =
+            coachId !== ""
+              ? peopleIds.includes(coachId)
+              : coachName !== "" && normalize(item.name) === coachName;
+          return districtOk && schoolOk && dateOk && coachOk;
+        };
+
+        let response = await fetchMondayData(buildQuery(null));
+        let page = response.data.boards[0].items_page;
+        if (page.items.some(matchesItem)) return { data: true, error: null };
+
+        let cursor: string | null = page.cursor;
+        while (cursor) {
+          response = await fetchMondayData(buildQuery(cursor));
+          page = response.data.next_items_page;
+          if (page.items.some(matchesItem)) return { data: true, error: null };
+          cursor = page.cursor;
+        }
+
+        return { data: false, error: null };
+      } catch (e) {
+        console.error(e);
+        return { data: null, error: new Error("hasExistingLog() went wrong") };
       }
     },
   };

--- a/app/domains/coach-log/service.ts
+++ b/app/domains/coach-log/service.ts
@@ -1,5 +1,6 @@
 import { Errorable } from "~/utils/errorable";
 import {
+  CoachLogIdentity,
   DistrictWithSchools,
   SessionDateOption,
   SubSchoolMap,
@@ -18,6 +19,7 @@ export interface CoachLogService {
     coachName: string,
     district: string
   ) => Promise<Errorable<SessionDateOption[]>>;
+  hasExistingLog: (query: CoachLogIdentity) => Promise<Errorable<boolean>>;
 }
 
 const uniqueSorted = (values: string[]) =>
@@ -33,15 +35,19 @@ const dateLabel = (ymd: string) =>
     timeZone: "UTC",
   }).format(new Date(`${ymd}T00:00:00Z`));
 
-// The parquet calendar is read from disk, which only works in local dev. On
-// deployed (Vercel) environments we serve these placeholder dates instead, until
-// the AWS-backed session-date source lands.
+// Placeholder session dates served everywhere until the real (AWS-backed)
+// session-date source is wired up. Used so the date dropdown is always usable.
 const DUMMY_SESSION_DATES: SessionDateOption[] = [
   "2026-06-01",
   "2026-06-03",
   "2026-06-08",
   "2026-06-10",
   "2026-06-15",
+  "2026-06-17",
+  "2026-06-19",
+  "2026-06-22",
+  "2026-06-24",
+  "2026-06-26",
 ].map((ymd) => ({ value: ymd, label: dateLabel(ymd) }));
 
 // Build the school dropdown options for a district. Districts with no schools
@@ -96,20 +102,14 @@ export function coachLogService(
       return { data: map, error: null };
     },
 
-    fetchSessionDates: async (coachName: string, district: string) => {
-      // Deployed environments can't read the parquet from disk — use placeholders.
-      if (process.env.VERCEL) {
-        return { data: DUMMY_SESSION_DATES, error: null };
-      }
-
-      const result = await repository.fetchSessionDates(coachName, district);
-      if (result.error || !result.data) return result;
-
-      const options = uniqueSorted(result.data).map((ymd) => ({
-        value: ymd,
-        label: dateLabel(ymd),
-      }));
-      return { data: options, error: null };
+    fetchSessionDates: async () => {
+      // TEMP: the real (AWS) session-date source isn't wired yet and the parquet
+      // only covers some coaches/districts, so serve dummy dates everywhere so
+      // the date dropdown is always usable. Restore the parquet/AWS-backed lookup
+      // (repository.fetchSessionDates) once the real source is available.
+      return { data: DUMMY_SESSION_DATES, error: null };
     },
+
+    hasExistingLog: (query) => repository.hasExistingLog(query),
   };
 }

--- a/app/routes/api.coach-log.exists.tsx
+++ b/app/routes/api.coach-log.exists.tsx
@@ -1,0 +1,40 @@
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import type { CoachLogIdentity } from "~/domains/coach-log/model";
+import { coachLogRepository } from "~/domains/coach-log/repository";
+import { coachLogService } from "~/domains/coach-log/service";
+
+// Pre-submit check: does a coach log already exist for this coach + district +
+// school + date? Used by the form to warn early and disable Submit. The submit
+// route enforces the same rule authoritatively.
+export const action = async ({ request }: ActionFunctionArgs) => {
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  try {
+    const query = (await request.json()) as Partial<CoachLogIdentity>;
+    const { district, school, sessionDate } = query;
+    if (!district || !school || !sessionDate) {
+      return json({ exists: false });
+    }
+
+    const service = coachLogService(coachLogRepository());
+    const { data, error } = await service.hasExistingLog({
+      coachMondayId: query.coachMondayId ?? "",
+      coachName: query.coachName ?? "",
+      district,
+      school,
+      sessionDate,
+    });
+    if (error) {
+      console.error("Error checking for existing coach log:", error);
+      // On error, don't block the coach client-side — the submit route still
+      // enforces the rule.
+      return json({ exists: false });
+    }
+    return json({ exists: data ?? false });
+  } catch (error) {
+    console.error("Error in coach-log exists API:", error);
+    return json({ exists: false }, { status: 500 });
+  }
+};

--- a/app/routes/api.coach-log.exists.tsx
+++ b/app/routes/api.coach-log.exists.tsx
@@ -15,7 +15,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const query = (await request.json()) as Partial<CoachLogIdentity>;
     const { district, school, sessionDate } = query;
     if (!district || !school || !sessionDate) {
-      return json({ exists: false });
+      return json({ exists: false, error: false });
     }
 
     const service = coachLogService(coachLogRepository());
@@ -28,13 +28,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     });
     if (error) {
       console.error("Error checking for existing coach log:", error);
-      // On error, don't block the coach client-side — the submit route still
-      // enforces the rule.
-      return json({ exists: false });
+      // Surface the failure so the form can warn the coach rather than silently
+      // treating it as "no duplicate".
+      return json({ exists: false, error: true });
     }
-    return json({ exists: data ?? false });
+    return json({ exists: data ?? false, error: false });
   } catch (error) {
     console.error("Error in coach-log exists API:", error);
-    return json({ exists: false }, { status: 500 });
+    return json({ exists: false, error: true }, { status: 500 });
   }
 };

--- a/app/routes/api.coach-log.submit.tsx
+++ b/app/routes/api.coach-log.submit.tsx
@@ -1,5 +1,10 @@
 import type { ActionFunctionArgs } from "@vercel/remix";
 import type { CoachLogSubmission } from "~/domains/coach-log/model";
+import {
+  COACH_LOG_BOARD_ID,
+  coachLogRepository,
+} from "~/domains/coach-log/repository";
+import { coachLogService } from "~/domains/coach-log/service";
 import { insertMondayData } from "~/domains/utils";
 import {
   readsShowsDistrictBlock,
@@ -15,12 +20,12 @@ import {
 // columns expect (matching the legacy form's serialization).
 const csv = (values: string[] | undefined) => (values ?? []).join(", ");
 
-// A real session date is YYYY-MM-DD; the "N/A" sentinel must not be written to a
-// Monday date column.
-const isRealDate = (value: string) => !!value && value !== "N/A";
+// Session date is YYYY-MM-DD (required); guard against an empty value just in
+// case so we never write a blank date column.
+const isRealDate = (value: string) => !!value;
 
 // Reuses the legacy Coach Log Form board + column schema.
-const BOARD_ID = 18416482214;
+const BOARD_ID = COACH_LOG_BOARD_ID;
 const GROUP_ID = "topics";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -95,6 +100,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   try {
+    // ---- Duplicate guard ------------------------------------------------
+    // One log per coach + district + school + date (cancelled logs count). This
+    // is the authoritative check; the form also pre-checks for a better UX.
+    const service = coachLogService(coachLogRepository());
+    const duplicate = await service.hasExistingLog({
+      coachMondayId,
+      coachName,
+      district,
+      school,
+      sessionDate,
+    });
+    if (duplicate.data) {
+      return new Response(null, {
+        status: 409,
+        statusText:
+          "A coach log already exists for this school on this date.",
+      });
+    }
+
     // ---- Parent item column values -------------------------------------
     const parentColumns: Record<string, unknown> = {
       text88__1: district, // District


### PR DESCRIPTION
Closes #123 — part of the Coach Log form revamp.

Stops coaches from accidentally submitting multiple logs for the same day.

## Duplicate-log prevention (one per coach + district + school + date)
- **Server (authoritative):** `api.coach-log.submit` returns **409** before creating the item if a matching log exists. `repository.hasExistingLog()` filters the board by district + school + date (exact) + the coach's Monday profile id (`people__1 any_of ["person-<id>"]`), then verifies every field in JS. Cancelled logs count.
- **Client (UX):** once district + school + date are chosen, `api.coach-log.exists` is checked — a spinner shows under the date question, then a warning + disabled Submit if a duplicate exists; a submit 409 is handled too.

## Require a real session date
- Removed the "N/A" fallback option + auto-select. No dates found → the field stays blank with a "contact the team" note, so a log can't be submitted without a real scheduled date.

## Interim dummy dates
- Until the AWS-backed source is wired, placeholder dates are served everywhere so the dropdown is usable. **Temporary** — the parquet/AWS lookup is left behind a `TEMP` note to restore.

## Modularization
- Extracted a `useDuplicateCheck` hook; moved the coach-log form hooks under `hooks/` (matching `auth/hooks/`).

Typecheck + build pass.

> Base is `feat/coach-log-updates` (stacked on the in-flight coach-log branches, off the previewed `feat/coach-log-form`). Retarget down the chain to `main` as the lower PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)