### PR TITLE
Coach Log: wire real session dates + add testing coach override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,9 @@ Server: `MONDAY_API_KEY`, `GOOGLE_SERVICE_CLIENTEMAIL` / `GOOGLE_SERVICE_PRIVATE
 ## Conventions
 - End git commit messages with the standard `Co-Authored-By` trailer; branch off `main` for new work (commit/push only when asked).
 - Keep diffs idiomatic to surrounding code; prefer the domain layering above over inlining external calls in routes/components.
+
+### Ticket → GitHub project board mapping
+When a change targets one of the forms below and you create a GitHub issue/ticket for it, add that ticket to the matching org Project board (`gh project item-add <N> --owner TeachingLabHQ --url <issue-url>`):
+- **Coach log form** → project board **19**
+- **Weekly project log form** → project board **21**
+- **Vendor payment form** (a.k.a. contractor payment form) → project board **22**

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -12,6 +12,7 @@ import { useSession } from "../auth/hooks/useSession";
 import { buildCoachLogSubmission } from "./build-submission";
 import { ParticipantRosterForm } from "./participant-roster-form";
 import {
+  canOverrideCoach,
   isNycCoachTypeDistrict,
   shouldShowEarlyChildhood,
   shouldShowReads,
@@ -19,6 +20,7 @@ import {
   shouldShowSubSchool,
 } from "./constants";
 import { CancellationQuestion } from "./questions/cancellation-question";
+import { CoachNameQuestion } from "./questions/coach-name-question";
 import { DistrictSchoolQuestion } from "./questions/district-school-question";
 import { EarlyChildhoodQuestion } from "./questions/early-childhood-question";
 import { ReadsQuestion } from "./questions/nyc/reads-question";
@@ -54,6 +56,17 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   >([]);
   const [loadingSessionDates, setLoadingSessionDates] = useState(false);
   const coachName = mondayProfile?.name ?? "";
+
+  // Testing-only coach override: allow-listed admins get a dropdown of every
+  // calendar coach so they can confirm session dates populate for anyone. The
+  // override only feeds the session-date lookup; the duplicate check and submit
+  // still use the real logged-in coach.
+  const canOverride = canOverrideCoach(mondayProfile?.email);
+  const [coachOverride, setCoachOverride] = useState("");
+  const [coachOptions, setCoachOptions] = useState<string[]>([]);
+  const [loadingCoachOptions, setLoadingCoachOptions] = useState(false);
+  const sessionDateCoachName =
+    canOverride && coachOverride ? coachOverride : coachName;
 
   // Submission status.
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -164,9 +177,32 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     };
   }, [district, school]);
 
+  // Testing-only: load the coach dropdown options once, for allow-listed admins.
+  useEffect(() => {
+    if (!canOverride) return;
+
+    let cancelledFetch = false;
+    setLoadingCoachOptions(true);
+    fetch("/api/coach-log/coach-names")
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelledFetch) setCoachOptions(data.coaches || []);
+      })
+      .catch(() => {
+        if (!cancelledFetch) setCoachOptions([]);
+      })
+      .finally(() => {
+        if (!cancelledFetch) setLoadingCoachOptions(false);
+      });
+
+    return () => {
+      cancelledFetch = true;
+    };
+  }, [canOverride]);
+
   // Fetch session dates whenever a coach + district are both known.
   useEffect(() => {
-    if (!district || !coachName) {
+    if (!district || !sessionDateCoachName) {
       setSessionDateOptions([]);
       return;
     }
@@ -176,7 +212,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     fetch("/api/coach-log/session-dates", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ coachName, district }),
+      body: JSON.stringify({ coachName: sessionDateCoachName, district }),
     })
       .then((r) => r.json())
       .then((data) => {
@@ -192,7 +228,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     return () => {
       cancelledFetch = true;
     };
-  }, [district, coachName]);
+  }, [district, sessionDateCoachName]);
 
   const handleSubmit = async (values: CoachLogValues) => {
     if (!mondayProfile?.name) {
@@ -260,6 +296,19 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
               )}
               className="flex flex-col gap-4"
             >
+              {canOverride && (
+                <CoachNameQuestion
+                  value={coachOverride}
+                  options={coachOptions}
+                  loading={loadingCoachOptions}
+                  onChange={(value) => {
+                    setCoachOverride(value);
+                    // The new coach has a different date list; drop any stale pick.
+                    form.setFieldValue("sessionDate", "");
+                  }}
+                />
+              )}
+
               <DistrictSchoolQuestion
                 form={form}
                 districts={districts}

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -105,18 +105,22 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   // change district/school/date above to resolve it).
   const lockActivities = checkingDuplicate || duplicateExists;
 
-  const showNycCoachType = isNycCoachTypeDistrict(district);
-  const showSubSchool = shouldShowSubSchool(district, nycCoachType);
-  const showEarlyChildhood = shouldShowEarlyChildhood(district, nycCoachType);
-  const showReads = shouldShowReads(district, nycCoachType);
-  const showSolves = shouldShowSolves(district, nycCoachType);
-  const showActivities = canceled !== "Yes";
-
   // Sub-school options are filtered from the loader map by district + school.
   const subSchoolOptions = useMemo(
     () => subSchools[subSchoolKey(district, school)] ?? [],
     [subSchools, district, school]
   );
+
+  const showNycCoachType = isNycCoachTypeDistrict(district);
+  // Sub-school shows for D75 + Solves, but only when the sheet actually has
+  // sub-schools for this district + school combo (otherwise there's nothing to
+  // pick, so we hide the question rather than show an empty dropdown).
+  const showSubSchool =
+    shouldShowSubSchool(district, nycCoachType) && subSchoolOptions.length > 0;
+  const showEarlyChildhood = shouldShowEarlyChildhood(district, nycCoachType);
+  const showReads = shouldShowReads(district, nycCoachType);
+  const showSolves = shouldShowSolves(district, nycCoachType);
+  const showActivities = canceled !== "Yes";
 
   const resetCoacheeSelections = () => {
     form.setFieldValue("coacheeRows", [{ ...EMPTY_COACHEE_ROW }]);

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -29,7 +29,9 @@ import { SolvesQuestion } from "./questions/nyc/solves-question";
 import { GroupCoachingQuestion } from "./questions/group-coaching-question";
 import { NycCoachTypeQuestion } from "./questions/nyc-coach-type-question";
 import { OneOnOneCoachingQuestion } from "./questions/one-on-one-coaching-question";
+import { PlSessionQuestion } from "./questions/pl-session-question";
 import { SessionDateQuestion } from "./questions/session-date-question";
+import { SessionDateCalendarQuestion } from "./questions/session-date-calendar-question";
 import { SubSchoolQuestion } from "./questions/sub-school-question";
 import { useDuplicateCheck } from "./hooks/use-duplicate-check";
 import {
@@ -84,6 +86,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
 
   const { district, school, nycCoachType, canceled, sessionDate } =
     form.values;
+  const readsIsPLSession = form.values.readsIsPLSession;
 
   // One log per coach + district + school + date — checked as soon as those are
   // chosen so the coach is warned before filling out the form.
@@ -122,6 +125,11 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const showSolves = shouldShowSolves(district, nycCoachType);
   const showActivities = canceled !== "Yes";
 
+  // A Reads coach logging a Professional Learning session: hide the coaching
+  // questions and pick the session date from a free calendar instead of the
+  // scheduled coaching-calendar dropdown.
+  const isPLSession = showReads && readsIsPLSession === "Yes";
+
   const resetCoacheeSelections = () => {
     form.setFieldValue("coacheeRows", [{ ...EMPTY_COACHEE_ROW }]);
     form.setFieldValue("groupParticipants", []);
@@ -147,6 +155,18 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     form.setFieldValue("school", value);
     form.setFieldValue("subSchool", "");
     resetCoacheeSelections();
+  };
+
+  // Selecting "Yes" auto-answers the 1:1 and group coaching questions "No"
+  // (they're hidden but still required), and clears the date since the input
+  // switches between the calendar and the scheduled dropdown.
+  const handlePLSessionChange = (value: string) => {
+    form.setFieldValue("readsIsPLSession", value as CoachLogValues["readsIsPLSession"]);
+    form.setFieldValue("sessionDate", "");
+    if (value === "Yes") {
+      form.setFieldValue("did1on1", "No");
+      form.setFieldValue("didGroupCoaching", "No");
+    }
   };
 
   const handleNycCoachTypeChange = (value: string) => {
@@ -340,15 +360,26 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
                 />
               )}
 
+              {showReads && (
+                <PlSessionQuestion
+                  form={form}
+                  onChange={handlePLSessionChange}
+                />
+              )}
+
               {showSubSchool && (
                 <SubSchoolQuestion form={form} options={subSchoolOptions} />
               )}
 
-              <SessionDateQuestion
-                form={form}
-                options={sessionDateOptions}
-                loading={loadingSessionDates}
-              />
+              {isPLSession ? (
+                <SessionDateCalendarQuestion form={form} />
+              ) : (
+                <SessionDateQuestion
+                  form={form}
+                  options={sessionDateOptions}
+                  loading={loadingSessionDates}
+                />
+              )}
 
               {checkingDuplicate && (
                 <div className="flex items-center gap-2">
@@ -382,15 +413,19 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
 
                 {showActivities && (
                   <>
-                    <OneOnOneCoachingQuestion
-                      form={form}
-                      coacheeOptions={coacheeOptions}
-                      loadingCoachees={loadingCoachees}
-                    />
-                    <GroupCoachingQuestion
-                      form={form}
-                      coacheeOptions={coacheeOptions}
-                    />
+                    {!isPLSession && (
+                      <>
+                        <OneOnOneCoachingQuestion
+                          form={form}
+                          coacheeOptions={coacheeOptions}
+                          loadingCoachees={loadingCoachees}
+                        />
+                        <GroupCoachingQuestion
+                          form={form}
+                          coacheeOptions={coacheeOptions}
+                        />
+                      </>
+                    )}
                     {showEarlyChildhood && (
                       <EarlyChildhoodQuestion form={form} />
                     )}

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -445,11 +445,11 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
                 <Notification
                   icon={<IconAlertTriangle size={20} />}
                   color="yellow"
-                  title="A coach log already exists for this school on this date."
+                  title="A coaching log for this district, site, and coach has already been submitted for this date."
                   withCloseButton={false}
                 >
-                  Only one log can be submitted per school per day. To make
-                  changes, contact the team.
+                  Please reach out to your project CPM or PMST member if you need
+                  to edit or view this log.
                 </Notification>
               )}
 

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -101,6 +101,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     district,
     school,
     sessionDate,
+    nycCoachType,
   });
 
   // While the check is running or a duplicate exists, the activity questions are

--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -3,6 +3,7 @@ import { IconAlertTriangle, IconCheck, IconX } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   subSchoolKey,
+  type CoachOption,
   type DistrictWithSchools,
   type SessionDateOption,
   type SubSchoolMap,
@@ -55,18 +56,25 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     SessionDateOption[]
   >([]);
   const [loadingSessionDates, setLoadingSessionDates] = useState(false);
-  const coachName = mondayProfile?.name ?? "";
 
-  // Testing-only coach override: allow-listed admins get a dropdown of every
-  // calendar coach so they can confirm session dates populate for anyone. The
-  // override only feeds the session-date lookup; the duplicate check and submit
-  // still use the real logged-in coach.
+  // Testing-only coach override: allow-listed admins get a dropdown of Monday
+  // coaches. When one is selected (by Monday id), that coach becomes the
+  // *effective* identity used everywhere — session-date lookup, the duplicate
+  // guard, and submission (item name = selected coach, people column = their
+  // Monday id). Everyone else (and the tester before picking) uses their own
+  // logged-in profile.
   const canOverride = canOverrideCoach(mondayProfile?.email);
-  const [coachOverride, setCoachOverride] = useState("");
-  const [coachOptions, setCoachOptions] = useState<string[]>([]);
+  const [coachOverrideId, setCoachOverrideId] = useState("");
+  const [coachOptions, setCoachOptions] = useState<CoachOption[]>([]);
   const [loadingCoachOptions, setLoadingCoachOptions] = useState(false);
-  const sessionDateCoachName =
-    canOverride && coachOverride ? coachOverride : coachName;
+
+  const overriddenCoach =
+    canOverride && coachOverrideId
+      ? coachOptions.find((c) => c.mondayId === coachOverrideId)
+      : undefined;
+  const coachName = overriddenCoach?.name ?? mondayProfile?.name ?? "";
+  const coachMondayId =
+    overriddenCoach?.mondayId ?? mondayProfile?.mondayProfileId ?? "";
 
   // Submission status.
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -85,7 +93,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     checkError: duplicateCheckError,
     setDuplicateExists,
   } = useDuplicateCheck({
-    coachMondayId: mondayProfile?.mondayProfileId ?? "",
+    coachMondayId,
     coachName,
     district,
     school,
@@ -202,7 +210,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
 
   // Fetch session dates whenever a coach + district are both known.
   useEffect(() => {
-    if (!district || !sessionDateCoachName) {
+    if (!district || !coachName) {
       setSessionDateOptions([]);
       return;
     }
@@ -212,7 +220,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     fetch("/api/coach-log/session-dates", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ coachName: sessionDateCoachName, district }),
+      body: JSON.stringify({ coachName, district }),
     })
       .then((r) => r.json())
       .then((data) => {
@@ -228,7 +236,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     return () => {
       cancelledFetch = true;
     };
-  }, [district, sessionDateCoachName]);
+  }, [district, coachName]);
 
   const handleSubmit = async (values: CoachLogValues) => {
     if (!mondayProfile?.name) {
@@ -247,9 +255,11 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(
+          // Effective coach: the override when an allow-listed tester has picked
+          // one, otherwise the logged-in profile.
           buildCoachLogSubmission(values, {
-            name: mondayProfile.name,
-            mondayProfileId: mondayProfile.mondayProfileId || "",
+            name: coachName,
+            mondayProfileId: coachMondayId,
           })
         ),
       });
@@ -298,11 +308,14 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
             >
               {canOverride && (
                 <CoachNameQuestion
-                  value={coachOverride}
-                  options={coachOptions}
+                  value={coachOverrideId}
+                  options={coachOptions.map((c) => ({
+                    value: c.mondayId,
+                    label: c.name,
+                  }))}
                   loading={loadingCoachOptions}
                   onChange={(value) => {
-                    setCoachOverride(value);
+                    setCoachOverrideId(value);
                     // The new coach has a different date list; drop any stale pick.
                     form.setFieldValue("sessionDate", "");
                   }}

--- a/app/components/coach-log/constants.ts
+++ b/app/components/coach-log/constants.ts
@@ -30,7 +30,11 @@ export const NYC_COACH_TYPE_OPTIONS = [
 // Testing-only: emails allowed to override the coach identity (pick any coach
 // from a dropdown) so they can verify session dates populate for everyone. For
 // all other users the coach is the logged-in profile and no dropdown shows.
-export const COACH_OVERRIDE_TESTER_EMAILS = ["yancheng.pan@teachinglab.org"];
+export const COACH_OVERRIDE_TESTER_EMAILS = [
+  "yancheng.pan@teachinglab.org",
+  "holly.corwin@teachinglab.org",
+  "duncan.gates@teachinglab.org",
+];
 
 export const canOverrideCoach = (email: string | undefined | null) =>
   !!email &&

--- a/app/components/coach-log/constants.ts
+++ b/app/components/coach-log/constants.ts
@@ -27,6 +27,15 @@ export const NYC_COACH_TYPE_OPTIONS = [
   "Math Coach (non-Solves/non-D75)",
 ];
 
+// Testing-only: emails allowed to override the coach identity (pick any coach
+// from a dropdown) so they can verify session dates populate for everyone. For
+// all other users the coach is the logged-in profile and no dropdown shows.
+export const COACH_OVERRIDE_TESTER_EMAILS = ["yancheng.pan@teachinglab.org"];
+
+export const canOverrideCoach = (email: string | undefined | null) =>
+  !!email &&
+  COACH_OVERRIDE_TESTER_EMAILS.includes(email.trim().toLowerCase());
+
 /** Coach types that reveal additional question sets (ported NYC Reads/Solves). */
 export const READS_COACH_TYPE = "Reads Coach";
 export const SOLVES_COACH_TYPE = "Solves Coach/D75 Math Coach";

--- a/app/components/coach-log/hooks/use-duplicate-check.ts
+++ b/app/components/coach-log/hooks/use-duplicate-check.ts
@@ -15,7 +15,8 @@ import type { CoachLogIdentity } from "~/domains/coach-log/model";
  * authoritative guard still lives in the submit route.
  */
 export function useDuplicateCheck(query: CoachLogIdentity) {
-  const { coachMondayId, coachName, district, school, sessionDate } = query;
+  const { coachMondayId, coachName, district, school, sessionDate, nycCoachType } =
+    query;
   const [duplicateExists, setDuplicateExists] = useState(false);
   const [checking, setChecking] = useState(false);
   const [checkError, setCheckError] = useState(false);
@@ -40,6 +41,7 @@ export function useDuplicateCheck(query: CoachLogIdentity) {
         district,
         school,
         sessionDate,
+        nycCoachType,
       }),
     })
       .then((r) => r.json())
@@ -66,7 +68,7 @@ export function useDuplicateCheck(query: CoachLogIdentity) {
     return () => {
       cancelled = true;
     };
-  }, [coachMondayId, coachName, district, school, sessionDate]);
+  }, [coachMondayId, coachName, district, school, sessionDate, nycCoachType]);
 
   return { duplicateExists, checking, checkError, setDuplicateExists };
 }

--- a/app/components/coach-log/questions/coach-name-question.tsx
+++ b/app/components/coach-log/questions/coach-name-question.tsx
@@ -1,0 +1,42 @@
+import { Loader, Select, Text } from "@mantine/core";
+
+type Props = {
+  value: string;
+  options: string[];
+  loading: boolean;
+  onChange: (value: string) => void;
+};
+
+/**
+ * Coach-identity override — TESTING ONLY. Rendered just for allow-listed admins
+ * (see canOverrideCoach). Picking a coach here replaces the logged-in profile
+ * name used to look up session dates, so the tester can confirm dates populate
+ * for any coach. Options are the distinct Coach/Facilitator names in the
+ * coaching PL calendar — i.e. exactly the names session dates are matched on.
+ */
+export const CoachNameQuestion = ({
+  value,
+  options,
+  loading,
+  onChange,
+}: Props) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <h1 className="font-medium text-lg">Coach (testing override)</h1>
+      <Text size="sm" c="white">
+        Testing only: select a coach to preview which session dates would
+        populate for them. Leave blank to use your own profile.
+      </Text>
+      <Select
+        value={value || null}
+        onChange={(val) => onChange(val || "")}
+        placeholder={loading ? "Loading coaches..." : "Select a coach"}
+        data={options}
+        searchable
+        clearable
+        disabled={loading}
+        rightSection={loading ? <Loader size="xs" /> : undefined}
+      />
+    </div>
+  );
+};

--- a/app/components/coach-log/questions/coach-name-question.tsx
+++ b/app/components/coach-log/questions/coach-name-question.tsx
@@ -2,17 +2,17 @@ import { Loader, Select, Text } from "@mantine/core";
 
 type Props = {
   value: string;
-  options: string[];
+  options: { value: string; label: string }[];
   loading: boolean;
   onChange: (value: string) => void;
 };
 
 /**
  * Coach-identity override — TESTING ONLY. Rendered just for allow-listed admins
- * (see canOverrideCoach). Picking a coach here replaces the logged-in profile
- * name used to look up session dates, so the tester can confirm dates populate
- * for any coach. Options are the distinct Coach/Facilitator names in the
- * coaching PL calendar — i.e. exactly the names session dates are matched on.
+ * (see canOverrideCoach). Picking a coach here replaces the logged-in identity
+ * (name + Monday id) used for session dates, the duplicate guard, and submission,
+ * so the tester can submit a log as any coach. Options come from Monday users;
+ * each option's value is the coach's Monday profile id.
  */
 export const CoachNameQuestion = ({
   value,

--- a/app/components/coach-log/questions/nyc/reads-question.tsx
+++ b/app/components/coach-log/questions/nyc/reads-question.tsx
@@ -1,5 +1,4 @@
 import { Select } from "@mantine/core";
-import type { YesNo } from "~/domains/coach-log/model";
 import { YES_NO_OPTIONS } from "../../constants";
 import type { CoachLogForm } from "../../hooks/use-coach-log-form";
 import {
@@ -23,41 +22,16 @@ type Props = {
 };
 
 /**
- * NYC Reads coach question set. Orchestrates the standalone questions (PL
- * session, capacity-builder, touchpoint) and delegates each touchpoint branch
- * to a focused sub-block.
+ * NYC Reads coach question set. The "Professional Learning session?" question is
+ * asked earlier (top-level, right after coach type) since it gates the coaching
+ * questions and the session-date input; this set covers capacity-builder,
+ * touchpoint, and the per-touchpoint sub-blocks.
  */
 export const ReadsQuestion = ({ form, district, school }: Props) => {
   const touchpoint = form.values.readsTouchpoint;
 
-  // A Professional Learning Session isn't a coaching activity, so selecting
-  // "Yes" auto-answers the 1:1 and group coaching questions "No". Selecting "No"
-  // (or clearing) leaves them untouched, so a coach who filled those in first
-  // doesn't have their answers overwritten.
-  const handlePLSessionChange = (value: string | null) => {
-    const next = (value ?? "") as YesNo | "";
-    form.setFieldValue("readsIsPLSession", next);
-    if (next === "Yes") {
-      form.setFieldValue("did1on1", "No");
-      form.setFieldValue("didGroupCoaching", "No");
-    }
-  };
-
   return (
     <>
-      <QuestionField
-        label="Are you logging a Professional Learning Session?*"
-        note="Professional Learning and coaching activities must be logged separately. If you are submitting a Professional Learning session, do not include any coaching activities in this log."
-      >
-        <Select
-          placeholder="Select Yes or No"
-          data={YES_NO_OPTIONS}
-          value={form.values.readsIsPLSession || null}
-          onChange={handlePLSessionChange}
-          error={form.errors.readsIsPLSession}
-        />
-      </QuestionField>
-
       {isReadsCapacityBuilderDistrict(district) && (
         <>
           <QuestionField label="Did the capacity builders provide a schedule prior to the visit?*">

--- a/app/components/coach-log/questions/pl-session-question.tsx
+++ b/app/components/coach-log/questions/pl-session-question.tsx
@@ -1,0 +1,36 @@
+import { Select, Text } from "@mantine/core";
+import { YES_NO_OPTIONS } from "../constants";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
+
+type Props = {
+  form: CoachLogForm;
+  onChange: (value: string) => void;
+};
+
+/**
+ * "Are you logging a Professional Learning Session?" — shown right after the
+ * coach-type question for NYC Reads coaches. A PL session isn't a coaching
+ * activity, so answering Yes hides the 1:1/group coaching questions and switches
+ * the session-date field to a free calendar pick (both handled in the form).
+ */
+export const PlSessionQuestion = ({ form, onChange }: Props) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <h1 className="font-medium text-lg">
+        Are you logging a Professional Learning Session?*
+      </h1>
+      <Text size="sm" c="white">
+        Professional Learning and coaching activities must be logged separately.
+        If you are submitting a Professional Learning session, do not include any
+        coaching activities in this log.
+      </Text>
+      <Select
+        placeholder="Select Yes or No"
+        data={YES_NO_OPTIONS}
+        value={form.values.readsIsPLSession || null}
+        onChange={(value) => onChange(value || "")}
+        error={form.errors.readsIsPLSession}
+      />
+    </div>
+  );
+};

--- a/app/components/coach-log/questions/session-date-calendar-question.tsx
+++ b/app/components/coach-log/questions/session-date-calendar-question.tsx
@@ -1,0 +1,49 @@
+import { DateInput } from "@mantine/dates";
+import { Text } from "@mantine/core";
+import type { CoachLogForm } from "../hooks/use-coach-log-form";
+
+type Props = {
+  form: CoachLogForm;
+};
+
+// YYYY-MM-DD <-> Date using LOCAL date parts, so the calendar day never shifts
+// across a timezone boundary (form state stays YYYY-MM-DD, like the scheduled
+// dropdown, so submission + the duplicate check are unchanged).
+const toDate = (ymd: string): Date | null => {
+  if (!ymd) return null;
+  const [y, m, d] = ymd.split("-").map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+};
+
+const toYmd = (date: Date | null): string => {
+  if (!date) return "";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
+/**
+ * Free calendar date picker for the session date, used for Professional Learning
+ * sessions (where the date isn't drawn from the coaching PL calendar). Writes
+ * the same YYYY-MM-DD `sessionDate` value the scheduled dropdown does.
+ */
+export const SessionDateCalendarQuestion = ({ form }: Props) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <h1 className="font-medium text-lg">
+        Please select the date of your Professional Learning session*
+      </h1>
+      <Text size="sm" c="white">
+        Select the date this Professional Learning session took place.
+      </Text>
+      <DateInput
+        placeholder="Select a date"
+        value={toDate(form.values.sessionDate)}
+        onChange={(date) => form.setFieldValue("sessionDate", toYmd(date))}
+        error={form.errors.sessionDate}
+      />
+    </div>
+  );
+};

--- a/app/domains/coach-log/model.ts
+++ b/app/domains/coach-log/model.ts
@@ -43,6 +43,17 @@ export type SessionDateOption = {
 };
 
 /**
+ * A selectable coach for the testing-only coach override. Sourced from Monday
+ * users (legacy form's approach) so it carries the Monday profile id — `name`
+ * is matched against the calendar's Coach/Facilitator for session dates and
+ * becomes the log's item name; `mondayId` populates the people column.
+ */
+export type CoachOption = {
+  name: string;
+  mondayId: string;
+};
+
+/**
  * The fields that uniquely identify a coach log for the duplicate check: one log
  * per coach + district + school + date. `coachMondayId` is preferred for the
  * coach match; `coachName` (the item name) is the fallback.

--- a/app/domains/coach-log/model.ts
+++ b/app/domains/coach-log/model.ts
@@ -64,6 +64,10 @@ export type CoachLogIdentity = {
   district: string;
   school: string;
   sessionDate: string;
+  /** NYC Coach Type — the same coach can log different types (e.g. Solves vs
+   * Reads) for the same school/date, so it's part of the duplicate key. Empty
+   * for non-NYC districts (matches other empty-coach-type logs). */
+  nycCoachType: string;
 };
 
 /** One 1:1 coaching entry. Each row becomes a Monday subitem on submission. */

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -319,10 +319,12 @@ export function coachLogRepository(): CoachLogRepository {
     },
 
     // True if a coach log already exists for this coach + district + school +
-    // date (one-log-per-day rule; cancelled logs count). Narrows the board to
-    // the district + school via Monday filters, then matches coach + date
-    // exactly in JS (the coach matches on the people column id, falling back to
-    // the item name). Returns false when there's no date to dedupe on.
+    // date + coach type (one-log-per-day rule; cancelled logs count). Narrows
+    // the board to the district + school via Monday filters, then matches coach
+    // + date + coach type exactly in JS (the coach matches on the people column
+    // id, falling back to the item name). Coach type is part of the key because
+    // one coach can log e.g. a Solves and a Reads session for the same
+    // school/date. Returns false when there's no date to dedupe on.
     hasExistingLog: async (query: CoachLogIdentity) => {
       try {
         const date = query.sessionDate.trim();
@@ -332,6 +334,7 @@ export function coachLogRepository(): CoachLogRepository {
         const school = normalize(query.school);
         const coachId = query.coachMondayId.trim();
         const coachName = normalize(query.coachName);
+        const coachType = normalize(query.nycCoachType);
 
         // Escape values interpolated into the GraphQL rule strings.
         const esc = (v: string) =>
@@ -354,7 +357,7 @@ export function coachLogRepository(): CoachLogRepository {
         }
         const rules = `[${ruleParts.join(", ")}]`;
 
-        const columnIds = `["text88__1","text5__1","date__1","people__1"]`;
+        const columnIds = `["text88__1","text5__1","date__1","people__1","text13__1"]`;
         const buildQuery = (cursor: string | null) =>
           cursor
             ? `{ next_items_page(limit: 500, cursor: "${cursor}") { cursor items { name column_values(ids:${columnIds}) { id text value } } } }`
@@ -384,13 +387,16 @@ export function coachLogRepository(): CoachLogRepository {
           const districtOk = normalize(col("text88__1")?.text) === district;
           const schoolOk = normalize(col("text5__1")?.text) === school;
           const dateOk = itemDate.trim() === date;
+          // Coach type must also match (empty == empty for non-NYC districts),
+          // so a coach's Solves and Reads logs for the same day don't collide.
+          const coachTypeOk = normalize(col("text13__1")?.text) === coachType;
           // Prefer matching by Monday profile id; fall back to the item name
           // (the coach name) only when no id is available.
           const coachOk =
             coachId !== ""
               ? peopleIds.includes(coachId)
               : coachName !== "" && normalize(item.name) === coachName;
-          return districtOk && schoolOk && dateOk && coachOk;
+          return districtOk && schoolOk && dateOk && coachOk && coachTypeOk;
         };
 
         let response = await fetchMondayData(buildQuery(null));

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -1,6 +1,5 @@
-import path from "node:path";
 import { google } from "googleapis";
-import { asyncBufferFromFile, parquetReadObjects } from "hyparquet";
+import { parquetReadObjects } from "hyparquet";
 import { Errorable } from "~/utils/errorable";
 import { fetchMondayData } from "~/domains/utils";
 import { CoachLogIdentity, DistrictWithSchools, SubSchoolRow } from "./model";
@@ -30,19 +29,22 @@ const COACHEE_ROSTER_BOARD_ID = 18416567790;
 //   (item name is the coach name). Shared with the submit route.
 export const COACH_LOG_BOARD_ID = 18416482214;
 
-// Interim session-date source: a parquet export of the coaching PL calendar,
-// committed at the repo root. Replaced later by the AWS-backed source. Read from
-// disk at request time and memoized (static interim data).
+// Session-date source: the coaching PL calendar, served as a parquet export by
+// the TL data service (a Monday webhook mirror — same columns the previously
+// committed parquet held). Authenticated with a token query param.
 //   - "Session Date": ISO date (UTC midnight)
 //   - "Coach/Facilitator": coach name (matched to the logged-in mondayProfile)
 //   - "L&R name": site/district label (same format as the district sheet)
-// NOTE(deploy): disk reads only work in local dev. On Vercel the service layer
-// short-circuits to placeholder dates (see DUMMY_SESSION_DATES in service.ts),
-// so this file isn't read or bundled in deployed environments.
-const SESSION_CALENDAR_PARQUET = path.join(
-  process.cwd(),
-  "coaching_pl_calendar.parquet"
-);
+// The endpoint doesn't support HTTP range requests, so we fetch the whole file
+// (small) and parse it in memory. Fetched via Node's global fetch (undici), so
+// it ignores http(s)_proxy — no proxy needed in dev, unlike the Sheets calls.
+const SESSION_CALENDAR_URL =
+  "https://tl-data.teachinglab.org/monday-webhook/calendar";
+
+// Memoize the parsed calendar per process with a short TTL: it's the same data
+// for every coach/district lookup, but it does change over time, so re-fetch
+// periodically rather than caching for the whole process lifetime.
+const CALENDAR_CACHE_TTL_MS = 5 * 60 * 1000;
 
 type CalendarRow = {
   "Session Date"?: unknown;
@@ -50,12 +52,28 @@ type CalendarRow = {
   "L&R name"?: unknown;
 };
 
-let calendarRowsCache: CalendarRow[] | null = null;
+let calendarCache: { rows: CalendarRow[]; fetchedAt: number } | null = null;
 async function loadCalendarRows(): Promise<CalendarRow[]> {
-  if (calendarRowsCache) return calendarRowsCache;
-  const file = await asyncBufferFromFile(SESSION_CALENDAR_PARQUET);
-  calendarRowsCache = (await parquetReadObjects({ file })) as CalendarRow[];
-  return calendarRowsCache;
+  if (calendarCache && Date.now() - calendarCache.fetchedAt < CALENDAR_CACHE_TTL_MS) {
+    return calendarCache.rows;
+  }
+
+  const token = cleanEnv(process.env.CALENDAR_API_TOKEN);
+  const url = `${SESSION_CALENDAR_URL}?token=${encodeURIComponent(token)}&format=parquet`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Calendar fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const buffer = await res.arrayBuffer();
+  const file = {
+    byteLength: buffer.byteLength,
+    slice: (start: number, end?: number) => buffer.slice(start, end),
+  };
+  const rows = (await parquetReadObjects({ file })) as CalendarRow[];
+
+  calendarCache = { rows, fetchedAt: Date.now() };
+  return rows;
 }
 
 const normalize = (v: unknown) => String(v ?? "").trim().toLowerCase();
@@ -107,6 +125,7 @@ export interface CoachLogRepository {
     coachName: string,
     district: string
   ): Promise<Errorable<string[]>>;
+  fetchCoachNames(): Promise<Errorable<string[]>>;
   hasExistingLog(query: CoachLogIdentity): Promise<Errorable<boolean>>;
 }
 
@@ -256,6 +275,26 @@ export function coachLogRepository(): CoachLogRepository {
         return {
           data: null,
           error: new Error("fetchSessionDates() went wrong"),
+        };
+      }
+    },
+
+    // Every distinct Coach/Facilitator in the calendar. Testing-only: lets an
+    // allow-listed admin impersonate any coach to confirm their session dates
+    // populate (see the coach-name override in the form). The service dedupes
+    // and sorts; these are the names session dates are actually matched on.
+    fetchCoachNames: async () => {
+      try {
+        const rows = await loadCalendarRows();
+        const names = rows
+          .map((r) => String(r["Coach/Facilitator"] ?? "").trim())
+          .filter((n) => n !== "");
+        return { data: names, error: null };
+      } catch (e) {
+        console.error(e);
+        return {
+          data: null,
+          error: new Error("fetchCoachNames() went wrong"),
         };
       }
     },

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -34,17 +34,19 @@ const COACHEE_ROSTER_BOARD_ID = 18416567790;
 //   (item name is the coach name). Shared with the submit route.
 export const COACH_LOG_BOARD_ID = 18416482214;
 
-// Session-date source: the coaching PL calendar, served as a parquet export by
-// the TL data service (a Monday webhook mirror — same columns the previously
-// committed parquet held). Authenticated with a token query param.
-//   - "Session Date": ISO date (UTC midnight)
-//   - "Coach/Facilitator": coach name (matched to the logged-in mondayProfile)
-//   - "L&R name": site/district label (same format as the district sheet)
+// Session-date source: the FY27 coaching PL calendar, served as a parquet export
+// by the TL data service (a Monday webhook mirror). Authenticated with a token
+// query param. Columns are snake_case:
+//   - session_date: ISO date (UTC midnight)
+//   - coach_facilitator: coach name (matched to the logged-in mondayProfile)
+//   - lr_name: site/district label (same format as the district sheet)
+//   - subsite: free-form school/site label (NOT yet used for filtering — its
+//     values don't match the form's school field; see fetchSessionDates)
 // The endpoint doesn't support HTTP range requests, so we fetch the whole file
 // (small) and parse it in memory. Fetched via Node's global fetch (undici), so
 // it ignores http(s)_proxy — no proxy needed in dev, unlike the Sheets calls.
 const SESSION_CALENDAR_URL =
-  "https://tl-data.teachinglab.org/monday-webhook/calendar";
+  "https://tl-data.teachinglab.org/monday-webhook/calendar_fy27";
 
 // Memoize the parsed calendar per process with a short TTL: it's the same data
 // for every coach/district lookup, but it does change over time, so re-fetch
@@ -52,9 +54,10 @@ const SESSION_CALENDAR_URL =
 const CALENDAR_CACHE_TTL_MS = 5 * 60 * 1000;
 
 type CalendarRow = {
-  "Session Date"?: unknown;
-  "Coach/Facilitator"?: unknown;
-  "L&R name"?: unknown;
+  session_date?: unknown;
+  coach_facilitator?: unknown;
+  lr_name?: unknown;
+  subsite?: unknown;
 };
 
 let calendarCache: { rows: CalendarRow[]; fetchedAt: number } | null = null;
@@ -255,10 +258,13 @@ export function coachLogRepository(): CoachLogRepository {
     },
 
     // Session dates for the logged-in coach at the selected district, read from
-    // the coaching PL calendar parquet. Matched on Coach/Facilitator == coach
-    // name and L&R name == district (both normalized). Returns raw YYYY-MM-DD
-    // values; the service dedupes, sorts, and formats labels. (The parquet has
-    // no school column, so dates are not scoped by school.)
+    // the coaching PL calendar parquet. Matched on coach_facilitator == coach
+    // name and lr_name == district (both normalized). Returns raw YYYY-MM-DD
+    // values; the service dedupes, sorts, and formats labels.
+    // NOTE: not scoped by school yet. The calendar's `subsite` column carries a
+    // school/site label, but its values (e.g. "M035: _Direct to Teacher") are
+    // free-form and don't match the form's `school` field, so filtering on it
+    // would drop all dates. Wire school scoping once the join is defined.
     fetchSessionDates: async (coachName: string, district: string) => {
       try {
         const coach = normalize(coachName);
@@ -268,10 +274,10 @@ export function coachLogRepository(): CoachLogRepository {
         const dates = rows
           .filter(
             (r) =>
-              normalize(r["Coach/Facilitator"]) === coach &&
-              normalize(r["L&R name"]) === dist
+              normalize(r.coach_facilitator) === coach &&
+              normalize(r.lr_name) === dist
           )
-          .map((r) => toYmd(r["Session Date"]))
+          .map((r) => toYmd(r.session_date))
           .filter((d) => d !== "");
 
         return { data: dates, error: null };

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -2,7 +2,12 @@ import { google } from "googleapis";
 import { parquetReadObjects } from "hyparquet";
 import { Errorable } from "~/utils/errorable";
 import { fetchMondayData } from "~/domains/utils";
-import { CoachLogIdentity, DistrictWithSchools, SubSchoolRow } from "./model";
+import {
+  CoachLogIdentity,
+  CoachOption,
+  DistrictWithSchools,
+  SubSchoolRow,
+} from "./model";
 
 // Coach-log reference data lives in one Google Sheet with several tabs. Tabs are
 // identified by gid (sheetId), which we resolve to a tab title before reading
@@ -125,7 +130,7 @@ export interface CoachLogRepository {
     coachName: string,
     district: string
   ): Promise<Errorable<string[]>>;
-  fetchCoachNames(): Promise<Errorable<string[]>>;
+  fetchCoaches(): Promise<Errorable<CoachOption[]>>;
   hasExistingLog(query: CoachLogIdentity): Promise<Errorable<boolean>>;
 }
 
@@ -279,23 +284,31 @@ export function coachLogRepository(): CoachLogRepository {
       }
     },
 
-    // Every distinct Coach/Facilitator in the calendar. Testing-only: lets an
-    // allow-listed admin impersonate any coach to confirm their session dates
-    // populate (see the coach-name override in the form). The service dedupes
-    // and sorts; these are the names session dates are actually matched on.
-    fetchCoachNames: async () => {
+    // Coaches for the testing-only override, sourced from Monday users (the
+    // legacy form's approach) so each carries a Monday profile id — used to
+    // populate the people column when an allow-listed admin impersonates a
+    // coach. Paginated; the service dedupes and sorts.
+    fetchCoaches: async () => {
       try {
-        const rows = await loadCalendarRows();
-        const names = rows
-          .map((r) => String(r["Coach/Facilitator"] ?? "").trim())
-          .filter((n) => n !== "");
-        return { data: names, error: null };
+        const buildQuery = (page: number) =>
+          `{ users(limit: 500, page: ${page}) { id name } }`;
+
+        const coaches: CoachOption[] = [];
+        for (let page = 1; ; page++) {
+          const res = await fetchMondayData(buildQuery(page));
+          const users: { id: unknown; name: unknown }[] = res?.data?.users ?? [];
+          for (const u of users) {
+            const name = String(u?.name ?? "").trim();
+            const mondayId = String(u?.id ?? "").trim();
+            if (name && mondayId) coaches.push({ name, mondayId });
+          }
+          if (users.length < 500) break;
+        }
+
+        return { data: coaches, error: null };
       } catch (e) {
         console.error(e);
-        return {
-          data: null,
-          error: new Error("fetchCoachNames() went wrong"),
-        };
+        return { data: null, error: new Error("fetchCoaches() went wrong") };
       }
     },
 

--- a/app/domains/coach-log/service.ts
+++ b/app/domains/coach-log/service.ts
@@ -1,6 +1,7 @@
 import { Errorable } from "~/utils/errorable";
 import {
   CoachLogIdentity,
+  CoachOption,
   DistrictWithSchools,
   SessionDateOption,
   SubSchoolMap,
@@ -19,7 +20,7 @@ export interface CoachLogService {
     coachName: string,
     district: string
   ) => Promise<Errorable<SessionDateOption[]>>;
-  fetchCoachNames: () => Promise<Errorable<string[]>>;
+  fetchCoaches: () => Promise<Errorable<CoachOption[]>>;
   hasExistingLog: (query: CoachLogIdentity) => Promise<Errorable<boolean>>;
 }
 
@@ -101,10 +102,20 @@ export function coachLogService(
       return { data: options, error: null };
     },
 
-    fetchCoachNames: async () => {
-      const result = await repository.fetchCoachNames();
+    fetchCoaches: async () => {
+      const result = await repository.fetchCoaches();
       if (result.error || !result.data) return result;
-      return { data: uniqueSorted(result.data), error: null };
+
+      // Dedupe by Monday id, then sort by name for the dropdown.
+      const seen = new Set<string>();
+      const unique = result.data.filter((c) => {
+        if (seen.has(c.mondayId)) return false;
+        seen.add(c.mondayId);
+        return true;
+      });
+      unique.sort((a, b) => a.name.localeCompare(b.name));
+
+      return { data: unique, error: null };
     },
 
     hasExistingLog: (query) => repository.hasExistingLog(query),

--- a/app/domains/coach-log/service.ts
+++ b/app/domains/coach-log/service.ts
@@ -19,6 +19,7 @@ export interface CoachLogService {
     coachName: string,
     district: string
   ) => Promise<Errorable<SessionDateOption[]>>;
+  fetchCoachNames: () => Promise<Errorable<string[]>>;
   hasExistingLog: (query: CoachLogIdentity) => Promise<Errorable<boolean>>;
 }
 
@@ -34,21 +35,6 @@ const dateLabel = (ymd: string) =>
     day: "numeric",
     timeZone: "UTC",
   }).format(new Date(`${ymd}T00:00:00Z`));
-
-// Placeholder session dates served everywhere until the real (AWS-backed)
-// session-date source is wired up. Used so the date dropdown is always usable.
-const DUMMY_SESSION_DATES: SessionDateOption[] = [
-  "2026-06-01",
-  "2026-06-03",
-  "2026-06-08",
-  "2026-06-10",
-  "2026-06-15",
-  "2026-06-17",
-  "2026-06-19",
-  "2026-06-22",
-  "2026-06-24",
-  "2026-06-26",
-].map((ymd) => ({ value: ymd, label: dateLabel(ymd) }));
 
 // Build the school dropdown options for a district. Districts with no schools
 // fall back to a single "N/A" entry; otherwise we prepend an "All Schools"
@@ -102,12 +88,23 @@ export function coachLogService(
       return { data: map, error: null };
     },
 
-    fetchSessionDates: async () => {
-      // TEMP: the real (AWS) session-date source isn't wired yet and the parquet
-      // only covers some coaches/districts, so serve dummy dates everywhere so
-      // the date dropdown is always usable. Restore the parquet/AWS-backed lookup
-      // (repository.fetchSessionDates) once the real source is available.
-      return { data: DUMMY_SESSION_DATES, error: null };
+    fetchSessionDates: async (coachName: string, district: string) => {
+      const result = await repository.fetchSessionDates(coachName, district);
+      if (result.error || !result.data) return result;
+
+      // Raw YYYY-MM-DD strings -> deduped, sorted, human-labeled options.
+      const options = uniqueSorted(result.data).map((ymd) => ({
+        value: ymd,
+        label: dateLabel(ymd),
+      }));
+
+      return { data: options, error: null };
+    },
+
+    fetchCoachNames: async () => {
+      const result = await repository.fetchCoachNames();
+      if (result.error || !result.data) return result;
+      return { data: uniqueSorted(result.data), error: null };
     },
 
     hasExistingLog: (query) => repository.hasExistingLog(query),

--- a/app/routes/api.coach-log.coach-names.tsx
+++ b/app/routes/api.coach-log.coach-names.tsx
@@ -2,22 +2,21 @@ import { json } from "@remix-run/node";
 import { coachLogRepository } from "~/domains/coach-log/repository";
 import { coachLogService } from "~/domains/coach-log/service";
 
-// Returns every distinct coach/facilitator in the coaching PL calendar.
-// Testing-only: the form fetches this just for an allow-listed admin so they can
-// impersonate any coach and confirm session dates populate. It's user-independent
-// reference data with no params, so it's a GET loader rather than a POST action.
+// Returns the coach options (name + Monday profile id) for the testing-only
+// coach override. Sourced from Monday users, so only fetched by the form for an
+// allow-listed admin. User-independent with no params, so it's a GET loader.
 export const loader = async () => {
   try {
     const service = coachLogService(coachLogRepository());
-    const { data, error } = await service.fetchCoachNames();
+    const { data, error } = await service.fetchCoaches();
     if (error) {
-      console.error("Error fetching coach names:", error);
+      console.error("Error fetching coaches:", error);
     }
     return json({ coaches: data || [] });
   } catch (error) {
     console.error("Error in coach-log coach-names API:", error);
     return json(
-      { coaches: [], error: "Failed to fetch coach names" },
+      { coaches: [], error: "Failed to fetch coaches" },
       { status: 500 }
     );
   }

--- a/app/routes/api.coach-log.coach-names.tsx
+++ b/app/routes/api.coach-log.coach-names.tsx
@@ -1,0 +1,24 @@
+import { json } from "@remix-run/node";
+import { coachLogRepository } from "~/domains/coach-log/repository";
+import { coachLogService } from "~/domains/coach-log/service";
+
+// Returns every distinct coach/facilitator in the coaching PL calendar.
+// Testing-only: the form fetches this just for an allow-listed admin so they can
+// impersonate any coach and confirm session dates populate. It's user-independent
+// reference data with no params, so it's a GET loader rather than a POST action.
+export const loader = async () => {
+  try {
+    const service = coachLogService(coachLogRepository());
+    const { data, error } = await service.fetchCoachNames();
+    if (error) {
+      console.error("Error fetching coach names:", error);
+    }
+    return json({ coaches: data || [] });
+  } catch (error) {
+    console.error("Error in coach-log coach-names API:", error);
+    return json(
+      { coaches: [], error: "Failed to fetch coach names" },
+      { status: 500 }
+    );
+  }
+};

--- a/app/routes/api.coach-log.exists.tsx
+++ b/app/routes/api.coach-log.exists.tsx
@@ -25,6 +25,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       district,
       school,
       sessionDate,
+      nycCoachType: query.nycCoachType ?? "",
     });
     if (error) {
       console.error("Error checking for existing coach log:", error);

--- a/app/routes/api.coach-log.session-dates.tsx
+++ b/app/routes/api.coach-log.session-dates.tsx
@@ -3,8 +3,9 @@ import { coachLogRepository } from "~/domains/coach-log/repository";
 import { coachLogService } from "~/domains/coach-log/service";
 
 // Returns the session-date options for a coach + district, read from the
-// coaching PL calendar. Depends on the logged-in coach (client-side) and the
-// selected district, so it's a client-driven POST rather than a loader.
+// coaching PL calendar (TL data service). Depends on the logged-in coach
+// (client-side) and the selected district, so it's a client-driven POST
+// rather than a loader.
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (request.method !== "POST") {
     return json({ error: "Method not allowed" }, { status: 405 });

--- a/app/routes/api.coach-log.submit.tsx
+++ b/app/routes/api.coach-log.submit.tsx
@@ -101,8 +101,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   try {
     // ---- Duplicate guard ------------------------------------------------
-    // One log per coach + district + school + date (cancelled logs count). This
-    // is the authoritative check; the form also pre-checks for a better UX.
+    // One log per coach + district + school + date + coach type (cancelled logs
+    // count). This is the authoritative check; the form also pre-checks for a
+    // better UX.
     const service = coachLogService(coachLogRepository());
     const duplicate = await service.hasExistingLog({
       coachMondayId,
@@ -110,6 +111,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       district,
       school,
       sessionDate,
+      nycCoachType,
     });
     if (duplicate.data) {
       return new Response(null, {


### PR DESCRIPTION
Resolves #126

## What
Coach Log: wire real session dates, add a testing-only coach override, and a batch of follow-on form fixes.

### 1. Real session dates (was a placeholder)
- `repository.fetchSessionDates` reads the coaching PL calendar from the TL data service (`/monday-webhook/calendar_fy27`, FY27, snake_case columns `session_date` / `coach_facilitator` / `lr_name`) instead of `DUMMY_SESSION_DATES` / the committed local parquet.
- Endpoint has no HTTP range support → fetch the whole file (~small) and parse in memory with hyparquet.
- Uses Node global `fetch` (undici) so it ignores `http(s)_proxy` — no dev proxy needed (unlike the Sheets calls). Memoized per-process with a 5-min TTL.
- `service.fetchSessionDates` dedupes/sorts/labels. Scoped to coach + district.
- New env var **`CALENDAR_API_TOKEN`** (added to local `.env`; **must also be added to Vercel**).

### 2. Testing-only coach override
- Coach-name dropdown shown **only** to allow-listed admins (`COACH_OVERRIDE_TESTER_EMAILS`: yancheng.pan@, holly.corwin@, duncan.gates@).
- Options sourced from Monday users (paginated `{ users { id name } }`) so each carries the Monday profile id (`CoachOption {name, mondayId}`, `fetchCoaches`).
- Selecting a coach sets the effective identity (name + Monday id) used **everywhere**: session-date lookup, the duplicate guard, and submission (item name = coach, people column = their Monday id).

### 3. Sub-school question
- Now hidden when the Google Sheet has no sub-schools for the selected district + school (still requires D75 + Solves), instead of rendering an empty dropdown.

### 4. NYC Reads PL-session reorder
- "Are you logging a Professional Learning Session?" moved out of the Reads set to a top-level question right after coach type (shown for Reads coaches).
- PL = Yes → hide 1:1 + group coaching and switch the session date to a free calendar pick; PL = No → keep coaching + the scheduled dropdown. Same `YYYY-MM-DD` value either way, so submission/validation/duplicate check are unchanged.

### 5. Duplicate-log guard + copy
- **Bug fix:** the one-log-per-day guard now also keys on NYC coach type (board column `text13__1`), so a coach's Solves and Reads logs for the same school/date no longer collide. Threaded through `CoachLogIdentity`, `hasExistingLog`, the exists pre-check, the authoritative submit guard, and the client hook (body + effect deps).
- Reworded the duplicate-found banner to reference district + site + coach and point coaches to their project CPM or PMST member.

## Known constraint / pending
- Session dates scope to coach + district only. The `/calendar_fy27` endpoint now includes a `subsite` (school/site) column, but its values are free-form labels that don't match the form's `school` field, so school-scoping is deferred until the join rule is defined.

## Follow-ups
- Add `CALENDAR_API_TOKEN` to Vercel env.
- Delete the now-unused committed `coaching_pl_calendar.parquet`.
- Wire school/subsite scoping once the calendar `subsite` ↔ form `school` join is defined.

## Verification
- `npm run typecheck` and `npm run build` pass.
- Verified live: FY27 dates populate per coach + district; coach-names route returns ~421 Monday coaches (with ids); the coach-type duplicate fix (Reads allowed vs. existing Solves; same Solves still blocked) confirmed against the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)