### PR TITLE
feat(coach-log): scope session dates by school

### DIFF
--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -150,6 +150,9 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const handleSchoolChange = (value: string) => {
     form.setFieldValue("school", value);
     form.setFieldValue("subSchool", "");
+    // Session dates are scoped by school, so the current date may no longer be
+    // valid for the new school.
+    form.setFieldValue("sessionDate", "");
     resetCoacheeSelections();
   };
 
@@ -205,7 +208,8 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     };
   }, [district, school]);
 
-  // Fetch session dates whenever a coach + district are both known.
+  // Fetch session dates whenever a coach + district are both known. The dates
+  // are scoped by school too, so re-fetch when the school changes.
   useEffect(() => {
     if (!district || !coachName) {
       setSessionDateOptions([]);
@@ -217,7 +221,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     fetch("/api/coach-log/session-dates", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ coachName, district }),
+      body: JSON.stringify({ coachName, district, school }),
     })
       .then((r) => r.json())
       .then((data) => {
@@ -233,7 +237,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     return () => {
       cancelledFetch = true;
     };
-  }, [district, coachName]);
+  }, [district, coachName, school]);
 
   const handleSubmit = async (values: CoachLogValues) => {
     if (!mondayProfile?.name) {

--- a/app/domains/coach-log/model.ts
+++ b/app/domains/coach-log/model.ts
@@ -35,11 +35,21 @@ export const subSchoolKey = (district: string, school: string) =>
  * One selectable session date for the date dropdown. `value` is YYYY-MM-DD (maps
  * straight into the Monday date column); `label` is a human-friendly rendering.
  * Sourced from the coaching PL calendar, scoped to the logged-in coach + the
- * selected district.
+ * selected district + school.
  */
 export type SessionDateOption = {
   value: string;
   label: string;
+};
+
+/**
+ * A raw calendar row matched to a coach + district: the session date (YYYY-MM-DD)
+ * and the free-form `subsite` label. The service resolves `subsite` to a canonical
+ * school (see resolveSubsiteSchool in the service) to scope dates by school.
+ */
+export type SessionDateRow = {
+  date: string;
+  subsite: string;
 };
 
 /**

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -6,6 +6,7 @@ import {
   CoachLogIdentity,
   CoachOption,
   DistrictWithSchools,
+  SessionDateRow,
   SubSchoolRow,
 } from "./model";
 
@@ -132,7 +133,7 @@ export interface CoachLogRepository {
   fetchSessionDates(
     coachName: string,
     district: string
-  ): Promise<Errorable<string[]>>;
+  ): Promise<Errorable<SessionDateRow[]>>;
   fetchCoaches(): Promise<Errorable<CoachOption[]>>;
   hasExistingLog(query: CoachLogIdentity): Promise<Errorable<boolean>>;
 }
@@ -259,26 +260,27 @@ export function coachLogRepository(): CoachLogRepository {
 
     // Session dates for the logged-in coach at the selected district, read from
     // the coaching PL calendar parquet. Matched on coach_facilitator == coach
-    // name and lr_name == district (both normalized). Returns raw YYYY-MM-DD
-    // values; the service dedupes, sorts, and formats labels.
-    // NOTE: not scoped by school yet. The calendar's `subsite` column carries a
-    // school/site label, but its values (e.g. "M035: _Direct to Teacher") are
-    // free-form and don't match the form's `school` field, so filtering on it
-    // would drop all dates. Wire school scoping once the join is defined.
+    // name and lr_name == district (both normalized). Returns each row's raw
+    // YYYY-MM-DD date plus its free-form `subsite` label; the service resolves
+    // the subsite to a canonical school (to scope by school), then dedupes,
+    // sorts, and formats labels.
     fetchSessionDates: async (coachName: string, district: string) => {
       try {
         const coach = normalize(coachName);
         const dist = normalize(district);
 
         const rows = await loadCalendarRows();
-        const dates = rows
+        const dates: SessionDateRow[] = rows
           .filter(
             (r) =>
               normalize(r.coach_facilitator) === coach &&
               normalize(r.lr_name) === dist
           )
-          .map((r) => toYmd(r.session_date))
-          .filter((d) => d !== "");
+          .map((r) => ({
+            date: toYmd(r.session_date),
+            subsite: String(r.subsite ?? "").trim(),
+          }))
+          .filter((r) => r.date !== "");
 
         return { data: dates, error: null };
       } catch (e) {

--- a/app/domains/coach-log/service.ts
+++ b/app/domains/coach-log/service.ts
@@ -18,7 +18,8 @@ export interface CoachLogService {
   fetchSubSchoolMap: () => Promise<Errorable<SubSchoolMap>>;
   fetchSessionDates: (
     coachName: string,
-    district: string
+    district: string,
+    school: string
   ) => Promise<Errorable<SessionDateOption[]>>;
   fetchCoaches: () => Promise<Errorable<CoachOption[]>>;
   hasExistingLog: (query: CoachLogIdentity) => Promise<Errorable<boolean>>;
@@ -26,6 +27,40 @@ export interface CoachLogService {
 
 const uniqueSorted = (values: string[]) =>
   [...new Set(values)].sort((a, b) => a.localeCompare(b));
+
+/**
+ * Resolve a calendar `subsite` label to one of a district's canonical school
+ * names (from the district/school sheet). The calendar decorates the school name
+ * with a trailing site detail — e.g. "Force Elementary_Coaching",
+ * "Force Elementary; Coaching" — and the separator is inconsistent (underscore,
+ * semicolon, colon, space), while school names can themselves contain those
+ * characters. So instead of splitting the string we match it against the known
+ * school list: return the longest canonical school whose name is a prefix of the
+ * subsite (up to a non-alphanumeric boundary, so "Forest" never matches
+ * "Forestville"). Longest wins so "Lincoln Elementary_Coaching" resolves to
+ * "Lincoln Elementary" rather than a shorter "Lincoln". Returns "" when nothing
+ * matches (e.g. district-level rows like "M035: _Direct to Teacher").
+ */
+const resolveSubsiteSchool = (subsite: string, schools: string[]): string => {
+  const s = subsite.trim().toLowerCase();
+  if (!s) return "";
+
+  let best = "";
+  for (const school of schools) {
+    const c = school.trim().toLowerCase();
+    if (!c || c.length <= best.length) continue;
+    if (s === c) {
+      best = school;
+      continue;
+    }
+    // Prefix match, but only at a word boundary: the char after the school name
+    // must be a separator (non-alphanumeric), not the middle of a longer word.
+    if (s.startsWith(c) && /^[^a-z0-9]/.test(s.slice(c.length))) {
+      best = school;
+    }
+  }
+  return best;
+};
 
 // "2026-06-01" -> "Monday, June 1, 2026" (UTC so the calendar date never shifts).
 const dateLabel = (ymd: string) =>
@@ -89,12 +124,41 @@ export function coachLogService(
       return { data: map, error: null };
     },
 
-    fetchSessionDates: async (coachName: string, district: string) => {
+    fetchSessionDates: async (
+      coachName: string,
+      district: string,
+      school: string
+    ) => {
       const result = await repository.fetchSessionDates(coachName, district);
       if (result.error || !result.data) return result;
 
+      let rows = result.data;
+
+      // Scope to the selected school when a specific one is chosen. "All Schools"
+      // and "N/A" are aggregate/placeholder options (see schoolOptions), so they
+      // keep every date for the district. We resolve each row's free-form
+      // `subsite` against the district's canonical school list rather than
+      // parsing it — see resolveSubsiteSchool.
+      const selected = school.trim();
+      if (selected && selected !== "All Schools" && selected !== "N/A") {
+        const districtsResult = await repository.fetchDistrictsWithSchools();
+        if (districtsResult.error || !districtsResult.data) {
+          return { data: null, error: districtsResult.error };
+        }
+        const canonicalSchools =
+          districtsResult.data.find(
+            (d) => d.district.trim().toLowerCase() === district.trim().toLowerCase()
+          )?.schools ?? [];
+        const target = selected.toLowerCase();
+        rows = rows.filter(
+          (r) =>
+            resolveSubsiteSchool(r.subsite, canonicalSchools).toLowerCase() ===
+            target
+        );
+      }
+
       // Raw YYYY-MM-DD strings -> deduped, sorted, human-labeled options.
-      const options = uniqueSorted(result.data).map((ymd) => ({
+      const options = uniqueSorted(rows.map((r) => r.date)).map((ymd) => ({
         value: ymd,
         label: dateLabel(ymd),
       }));

--- a/app/routes/api.coach-log.session-dates.tsx
+++ b/app/routes/api.coach-log.session-dates.tsx
@@ -2,23 +2,27 @@ import { json, type ActionFunctionArgs } from "@remix-run/node";
 import { coachLogRepository } from "~/domains/coach-log/repository";
 import { coachLogService } from "~/domains/coach-log/service";
 
-// Returns the session-date options for a coach + district, read from the
-// coaching PL calendar (TL data service). Depends on the logged-in coach
-// (client-side) and the selected district, so it's a client-driven POST
-// rather than a loader.
+// Returns the session-date options for a coach + district + school, read from
+// the coaching PL calendar (TL data service). Depends on the logged-in coach
+// (client-side) and the selected district + school, so it's a client-driven
+// POST rather than a loader.
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (request.method !== "POST") {
     return json({ error: "Method not allowed" }, { status: 405 });
   }
 
   try {
-    const { coachName, district } = await request.json();
+    const { coachName, district, school } = await request.json();
     if (!coachName || !district) {
       return json({ dates: [] });
     }
 
     const service = coachLogService(coachLogRepository());
-    const { data, error } = await service.fetchSessionDates(coachName, district);
+    const { data, error } = await service.fetchSessionDates(
+      coachName,
+      district,
+      school ?? ""
+    );
     if (error) {
       console.error("Error fetching session dates:", error);
     }


### PR DESCRIPTION
Closes #132.

## What & why

Session dates were keyed only by **coach + district**. This scopes them by **school** too.

The calendar API's school label (`subsite`) is decorated with a trailing site detail — e.g. `Force Elementary_Coaching` for the canonical `Force Elementary` — and the separator is inconsistent (underscore/semicolon/colon/space), with school names potentially containing those characters. So instead of splitting the string, `resolveSubsiteSchool` matches the `subsite` against the district's **known** canonical school list and returns the **longest** school that is a prefix at a word boundary. That's separator-agnostic and resolves prefix-overlapping names (`Lincoln` vs `Lincoln Elementary`) correctly.

## Changes

- **`service.ts`** — new `resolveSubsiteSchool` helper; `fetchSessionDates(coachName, district, school)` filters rows to the selected school. `All Schools`/`N/A`/empty keep every date (unchanged behavior). Non-school rows (e.g. `M035: _Direct to Teacher`) resolve to `""` and drop out.
- **`repository.ts`** — `fetchSessionDates` now returns `{ date, subsite }` rows so the service can see the site label.
- **`model.ts`** — add `SessionDateRow` type.
- **`api.coach-log.session-dates.tsx`** — accept and pass `school`.
- **`coach-log-form.tsx`** — send `school`, re-fetch dates on school change, and clear the selected date on school change so a stale date can't linger.

## Verification

`npm run typecheck` and `npm run build` both pass.

## Open questions (see #132)

- Strict filtering, no fail-open: a heuristic miss shows zero dates rather than district-wide.
- Extra Google Sheets read per request for the canonical list; cache if latency shows.
- Confirm live data: any prefix-overlapping school names, and do decorations ever lead the string (would need "contains" not prefix)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)