### PR TITLE
feat(vendor-payment): lock current-month logging until the 16th

### DIFF
--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -311,7 +311,7 @@ export const getDefaultVendorPaymentDate = (): Date => {
 
 /**
  * Whether to show the notice asking coaches to hold off on July submissions
- * until July 15. Shows only through July 15 and clears itself afterwards.
+ * until July 16. Shows through July 15 and clears itself once July unlocks on the 16th.
  */
 export const shouldShowJulyHoldNotice = (): boolean => {
   const today = new Date();

--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -272,10 +272,10 @@ export const shouldExcludeVendorPaymentDate = (date: Date): boolean => {
   const dateMonth = date.getMonth();
   const dateYear = date.getFullYear();
   
-    // If today is 5th or earlier, only allow prior month dates (the prior month is
-    // still being finalized until the 5th). Current month dates stay locked until
-    // the 6th so nothing can be logged for the current month before then.
-    if (currentDay <= 5) {
+    // If today is the 15th or earlier, only allow prior month dates (the prior
+    // month is still being finalized). Current month dates stay locked until the
+    // 16th so nothing can be logged for the current month before then.
+    if (currentDay <= 15) {
       const priorMonth = currentMonth === 0 ? 11 : currentMonth - 1;
       const priorMonthYear = currentMonth === 0 ? currentYear - 1 : currentYear;
 
@@ -284,9 +284,9 @@ export const shouldExcludeVendorPaymentDate = (date: Date): boolean => {
         return false; // Don't exclude prior month dates
       }
     } else {
-      // If today is 6th or later, only allow current month dates from today onwards
+      // If today is the 16th or later, only allow current month dates
       if (dateYear === currentYear && dateMonth === currentMonth ) {
-        return false; // Don't exclude current month dates from today onwards
+        return false; // Don't exclude current month dates
       }
     }
   
@@ -296,13 +296,13 @@ export const shouldExcludeVendorPaymentDate = (date: Date): boolean => {
 
 /**
  * Default date to pre-select in the work date picker.
- * Before the 6th, current-month dates are locked (see shouldExcludeVendorPaymentDate),
+ * Before the 16th, current-month dates are locked (see shouldExcludeVendorPaymentDate),
  * so default to the last day of the previous month — a valid, selectable date —
  * instead of today, which would otherwise let users submit for the current month.
  */
 export const getDefaultVendorPaymentDate = (): Date => {
   const today = new Date();
-  if (today.getDate() <= 5) {
+  if (today.getDate() <= 15) {
     // Day 0 of the current month resolves to the last day of the previous month.
     return new Date(today.getFullYear(), today.getMonth(), 0);
   }

--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -272,19 +272,16 @@ export const shouldExcludeVendorPaymentDate = (date: Date): boolean => {
   const dateMonth = date.getMonth();
   const dateYear = date.getFullYear();
   
-    // If today is 5th or earlier, allow prior month dates + ALL current month dates
+    // If today is 5th or earlier, only allow prior month dates (the prior month is
+    // still being finalized until the 5th). Current month dates stay locked until
+    // the 6th so nothing can be logged for the current month before then.
     if (currentDay <= 5) {
       const priorMonth = currentMonth === 0 ? 11 : currentMonth - 1;
       const priorMonthYear = currentMonth === 0 ? currentYear - 1 : currentYear;
-      
+
       // Allow all prior month dates
       if (dateYear === priorMonthYear && dateMonth === priorMonth) {
         return false; // Don't exclude prior month dates
-      }
-      
-      // Allow ALL current month dates (including future dates)
-      if (dateYear === currentYear && dateMonth === currentMonth) {
-        return false; // Don't exclude any current month dates
       }
     } else {
       // If today is 6th or later, only allow current month dates from today onwards
@@ -295,6 +292,31 @@ export const shouldExcludeVendorPaymentDate = (date: Date): boolean => {
   
   // Exclude all other dates
   return true;
+};
+
+/**
+ * Default date to pre-select in the work date picker.
+ * Before the 6th, current-month dates are locked (see shouldExcludeVendorPaymentDate),
+ * so default to the last day of the previous month — a valid, selectable date —
+ * instead of today, which would otherwise let users submit for the current month.
+ */
+export const getDefaultVendorPaymentDate = (): Date => {
+  const today = new Date();
+  if (today.getDate() <= 5) {
+    // Day 0 of the current month resolves to the last day of the previous month.
+    return new Date(today.getFullYear(), today.getMonth(), 0);
+  }
+  return today;
+};
+
+/**
+ * Whether to show the notice asking coaches to hold off on July submissions
+ * until July 15. Shows only through July 15 and clears itself afterwards.
+ */
+export const shouldShowJulyHoldNotice = (): boolean => {
+  const today = new Date();
+  const JULY = 6; // zero-based month index
+  return today.getMonth() === JULY && today.getDate() <= 15;
 };
 
 export const filterVendorPaymentProjects = (projects: string[]): string[] => {

--- a/app/components/vendor-payment-form/vendor-payment-form.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-form.tsx
@@ -212,7 +212,7 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
                     withCloseButton={false}
                     className="mt-2"
                   >
-                    Please hold off on submitting July entries until July 15.
+                    Please hold off on submitting July entries until July 16.
                   </Notification>
                 )}
               </div>

--- a/app/components/vendor-payment-form/vendor-payment-form.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-form.tsx
@@ -1,15 +1,17 @@
 import { Button, Notification, Tabs } from "@mantine/core";
 import { DateInput } from "@mantine/dates";
 import { useFetcher, useNavigate, useLoaderData } from "@remix-run/react";
-import { IconCheck, IconX } from "@tabler/icons-react";
+import { IconCheck, IconInfoCircle, IconX } from "@tabler/icons-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { CoachFacilitatorDetails } from "~/domains/coachFacilitator/repository";
 import { Reminders } from "../weekly-project-log/reminders";
 import { PaymentHistory } from "./payment-history/payment-history";
 import {
+  getDefaultVendorPaymentDate,
   parseStoredTask,
   REMINDER_ITEMS,
   shouldExcludeVendorPaymentDate,
+  shouldShowJulyHoldNotice,
 } from "./utils";
 import { VendorPaymentWidget } from "./vendor-payment-widget";
 import { loader } from "~/routes/vendor-payment-form";
@@ -27,7 +29,9 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
   const [isValidated, setIsValidated] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [workDate, setWorkDate] = useState<Date | null>(new Date());
+  const [workDate, setWorkDate] = useState<Date | null>(
+    getDefaultVendorPaymentDate()
+  );
   const [activeTab, setActiveTab] = useState("new");
   const [vendorPaymentEntries, setVendorPaymentEntries] = useState([
     {
@@ -200,6 +204,17 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
                   excludeDate={shouldExcludeVendorPaymentDate}
                   error={isValidated === true && !workDate ? "Date is required" : null}
                 />
+                {shouldShowJulyHoldNotice() && (
+                  <Notification
+                    icon={<IconInfoCircle size={20} />}
+                    color="yellow"
+                    title="July submissions on hold"
+                    withCloseButton={false}
+                    className="mt-2"
+                  >
+                    Please hold off on submitting July entries until July 15.
+                  </Notification>
+                )}
               </div>
 
               <VendorPaymentWidget


### PR DESCRIPTION
## Summary
Adjusts the vendor / project consultant payment form so the current month can't be logged before the monthly finalization window closes.

- **Lock current-month dates until the 16th** — `shouldExcludeVendorPaymentDate` previously allowed *all* current-month dates whenever today was the 5th or earlier, letting users log e.g. July dates early. Now, through the 15th, only prior-month dates are selectable; current-month dates unlock on the 16th.
- **Default date fix** — the picker previously defaulted to `new Date()` (today), which sat on a now-locked current-month date. Added `getDefaultVendorPaymentDate()`: through the 15th it defaults to the **last day of the previous month** (a valid, selectable date); on the 16th or later it defaults to today.
- **July hold notice** — added an advisory `Notification` under the date field asking coaches to hold off on July submissions until July 15. Shows only through July 15, then clears itself (`shouldShowJulyHoldNotice()`).

## Notes
- The date rule is enforced **client-side** via the picker's `excludeDate`, consistent with the existing design; the submit route is unchanged.
- The July-15 notice is advisory only and does not hard-block submission.

## Test plan
- [x] `npm run typecheck` passes
- [ ] On the 1st–15th: picker only allows prior-month dates and defaults to the last day of the prior month
- [ ] On the 16th+: picker allows current-month dates and defaults to today
- [ ] July 1–15: hold notice appears under the date field; gone after July 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)