### PR TITLE
feat(coach-log): shareable ?tab= deep link for the participant roster

### DIFF
--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -1,4 +1,5 @@
 import { Button, Loader, Notification, Tabs, Text } from "@mantine/core";
+import { useSearchParams } from "@remix-run/react";
 import { IconAlertTriangle, IconCheck, IconX } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -44,9 +45,36 @@ type Props = {
   subSchools: SubSchoolMap;
 };
 
+// Tabs are mirrored into the URL (?tab=) so each tab has a shareable deep link
+// — e.g. the participant roster can be handed out as /coach-log-form?tab=roster
+// without asking people to open the coach log and click the tab first.
+const TAB_VALUES = ["coach-log", "roster"] as const;
+const DEFAULT_TAB = "coach-log";
+
 export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const { mondayProfile } = useSession();
   const form = useCoachLogForm();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const activeTab = TAB_VALUES.includes(tabParam as (typeof TAB_VALUES)[number])
+    ? tabParam
+    : DEFAULT_TAB;
+
+  const handleTabChange = (value: string | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (!value || value === DEFAULT_TAB) {
+          next.delete("tab");
+        } else {
+          next.set("tab", value);
+        }
+        return next;
+      },
+      { replace: true, preventScrollReset: true }
+    );
+  };
 
   // Reference data (not form state) — coachees depend on district + school.
   const [coacheeOptions, setCoacheeOptions] = useState<string[]>([]);
@@ -290,7 +318,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   return (
     <div className="w-full h-full grid grid-cols-12 gap-8 py-8">
       <div className="col-start-2 col-span-10 h-fit p-8 rounded-[25px] bg-white/30 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.6)] text-white">
-        <Tabs defaultValue="coach-log">
+        <Tabs value={activeTab} onChange={handleTabChange}>
           <Tabs.List>
             <Tabs.Tab value="coach-log" className="hover:bg-white/10">
               Coach Log

--- a/app/routes/coach-log-form.tsx
+++ b/app/routes/coach-log-form.tsx
@@ -1,5 +1,5 @@
 import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
+import { useLoaderData, type ShouldRevalidateFunction } from "@remix-run/react";
 import { useSession } from "~/components/auth/hooks/useSession";
 import { CoachLogForm } from "~/components/coach-log/coach-log-form";
 import { coachLogRepository } from "~/domains/coach-log/repository";
@@ -29,6 +29,15 @@ export const loader = async () => {
     subSchools: subSchools.data ?? {},
   });
 };
+
+// The loader only returns static reference data (districts/sub-schools) that
+// doesn't depend on the URL. Skip revalidation when we're just navigating within
+// the same page — e.g. the ?tab= switch — so tab changes are instant instead of
+// waiting on a fresh Google Sheets fetch.
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  currentUrl,
+  nextUrl,
+}) => currentUrl.pathname !== nextUrl.pathname;
 
 export default function CoachLogFormRoute() {
   const { mondayProfile, isLoading: isSessionLoading } = useSession();


### PR DESCRIPTION
Closes #136

## What & why

The participant roster only existed as a tab inside `/coach-log-form`, so there was no direct link to hand out — people had to open the coach log and click the tab. A coworker flagged this when trying to share the roster ahead of go-live.

This mirrors the active tab into the URL so each tab has a shareable deep link:

| URL | Opens on |
|---|---|
| `/coach-log-form` | Coach Log tab (default) |
| `/coach-log-form?tab=roster` | Participant Roster tab ← the link to share |

## Changes

- **`coach-log-form.tsx` (component):** `Tabs` are now controlled and synced to a `?tab=` search param via `useSearchParams`.
  - Unknown/invalid param values fall back to the Coach Log tab.
  - The default tab writes **no** param, keeping the URL clean.
  - Tab switches use `replace: true` (no back-button clutter) + `preventScrollReset`.
- **`coach-log-form.tsx` (route):** added `shouldRevalidate` that returns `false` when the pathname is unchanged. The loader only returns static reference data (districts/sub-schools from Google Sheets, ~1s), so a tab switch no longer waits on a refetch — the tab change is instant. Genuine navigation / full reload still runs the loader normally.

## Notes

- Kept the existing tab structure; no standalone route added.
- Typecheck passes (`tsc --noEmit`).

## Testing

- [x] `tsc --noEmit` clean
- [ ] Click roster tab → URL becomes `?tab=roster`; switch back → param clears
- [ ] Open `/coach-log-form?tab=roster` fresh → lands on roster tab
- [ ] Tab switch is instant (no ~1s lag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)