### PR TITLE
feat(vendor-payment): CPF updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ See `supabase/migrations/` for detailed schema definitions.
 The project includes automated email functionality via Supabase Edge Functions:
 
 - **Function**: `send-vendor-payment-summaries`
-- **Trigger**: Monthly cron job (6th of each month)
+- **Trigger**: Monthly cron job (3rd of each month)
 - **Batch Size**: 15 emails per invocation
 - **Rate Limiting**: 600ms delay between emails
 

--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -5,6 +5,7 @@ export const storedTaskSchema = z.object({
   taskName: z.string(),
   rate: z.number(),
   maxHours: z.number().nullable(),
+  fixedHours: z.number().nullable().optional(),
 });
 
 export type StoredTask = z.infer<typeof storedTaskSchema>;
@@ -43,7 +44,8 @@ export type TaskDetails = {
     "Tier 2": number | null;
     "Tier 3": number | null;
     "Tier 4": number | null;
-  }|null;
+  } | null;
+  fixedHours?: number | null;
 };
 
 export const facilitationTaskOptions: TaskDetails[] = [
@@ -53,62 +55,44 @@ export const facilitationTaskOptions: TaskDetails[] = [
     "Tier 2": null,
     "Tier 3": null,
     "Tier 4": null,
-    maxHours: {
-      "Tier 1": 1,
-      "Tier 2": null,
-      "Tier 3": null,
-      "Tier 4": null,
-    },
+    maxHours: null,
+    fixedHours: 1,
   },
   {
-    taskName:
-      "Lead coaching activities: 1-1 coaching sessions, micro group PL, or walkthrough",
-    "Tier 1": 110,
-    "Tier 2": 125,
-    "Tier 3": 140,
-    "Tier 4": null,
-    maxHours: {
-      "Tier 1": 6,
-      "Tier 2": 6,
-      "Tier 3": 6,
-      "Tier 4": null,
-    },
-  },
-  {
-    taskName:
-      "Lead coaching preparation & follow-up: internalization or preparation for coaching sessions; follow-up activities; completion of Coaching Action Plans and Coaching Logs",
-    "Tier 1": 50,
-    "Tier 2": 50,
-    "Tier 3": 50,
-    "Tier 4": null,
-    maxHours: {
-      "Tier 1": 1.5,
-      "Tier 2": 1.5,
-      "Tier 3": 1.5,
-      "Tier 4": null,
-    },
-  },
-  {
-    taskName: "Lead Facilitation of group Professional Learning course",
-    "Tier 1": 150,
-    "Tier 2": 165,
-    "Tier 3": 180,
-    "Tier 4": null,
-    maxHours: {
-      "Tier 1": 6,
-      "Tier 2": 6,
-      "Tier 3": 6,
-      "Tier 4": null,
-    },
-  },
-  {
-    taskName:
-      "Tech/Support Facilitation of group Professional Learning courses",
-    "Tier 1": 50,
-    "Tier 2": 50,
-    "Tier 3": 50,
+    taskName: "1/3 Day: ~2hrs C/F",
+    "Tier 1": 350,
+    "Tier 2": 370,
+    "Tier 3": 400,
     "Tier 4": null,
     maxHours: null,
+    fixedHours: 1,
+  },
+  {
+    taskName: "1/2 Day: ~3hrs C/F",
+    "Tier 1": 500,
+    "Tier 2": 540,
+    "Tier 3": 585,
+    "Tier 4": null,
+    maxHours: null,
+    fixedHours: 1,
+  },
+  {
+    taskName: "Full Day: ~6hrs C/F",
+    "Tier 1": 1000,
+    "Tier 2": 1080,
+    "Tier 3": 1170,
+    "Tier 4": null,
+    maxHours: null,
+    fixedHours: 1,
+  },
+  {
+    taskName: "Extended Day: 6hrs+ C/F",
+    "Tier 1": 1150,
+    "Tier 2": 1250,
+    "Tier 3": 1320,
+    "Tier 4": null,
+    maxHours: null,
+    fixedHours: 1,
   },
   {
     taskName: "Second Facilitation of group Professional Learning courses",
@@ -140,7 +124,7 @@ export const facilitationTaskOptions: TaskDetails[] = [
     maxHours: null,
   },
   {
-    taskName: "Site Context + Support: Meetings and collaborations with project team members and/or partners to support the overall project success",
+    taskName: "Collaboration",
     "Tier 1": 50,
     "Tier 2": 50,
     "Tier 3": 50,

--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -234,52 +234,25 @@ export const shouldExcludeVendorPaymentDate = (date: Date): boolean => {
   
   const dateMonth = date.getMonth();
   const dateYear = date.getFullYear();
-  
-    // If today is the 15th or earlier, only allow prior month dates (the prior
-    // month is still being finalized). Current month dates stay locked until the
-    // 16th so nothing can be logged for the current month before then.
-    if (currentDay <= 15) {
-      const priorMonth = currentMonth === 0 ? 11 : currentMonth - 1;
-      const priorMonthYear = currentMonth === 0 ? currentYear - 1 : currentYear;
 
-      // Allow all prior month dates
-      if (dateYear === priorMonthYear && dateMonth === priorMonth) {
-        return false; // Don't exclude prior month dates
-      }
-    } else {
-      // If today is the 16th or later, only allow current month dates
-      if (dateYear === currentYear && dateMonth === currentMonth ) {
-        return false; // Don't exclude current month dates
-      }
+  // Current month dates are always allowed
+  if (dateYear === currentYear && dateMonth === currentMonth) {
+    return false;
+  }
+
+  // Through the 2nd, also allow prior month dates (the prior month is still
+  // being finalized; entries auto-submit for payment on the 3rd)
+  if (currentDay <= 2) {
+    const priorMonth = currentMonth === 0 ? 11 : currentMonth - 1;
+    const priorMonthYear = currentMonth === 0 ? currentYear - 1 : currentYear;
+
+    if (dateYear === priorMonthYear && dateMonth === priorMonth) {
+      return false;
     }
-  
+  }
+
   // Exclude all other dates
   return true;
-};
-
-/**
- * Default date to pre-select in the work date picker.
- * Before the 16th, current-month dates are locked (see shouldExcludeVendorPaymentDate),
- * so default to the last day of the previous month — a valid, selectable date —
- * instead of today, which would otherwise let users submit for the current month.
- */
-export const getDefaultVendorPaymentDate = (): Date => {
-  const today = new Date();
-  if (today.getDate() <= 15) {
-    // Day 0 of the current month resolves to the last day of the previous month.
-    return new Date(today.getFullYear(), today.getMonth(), 0);
-  }
-  return today;
-};
-
-/**
- * Whether to show the notice asking coaches to hold off on July submissions
- * until July 16. Shows through July 15 and clears itself once July unlocks on the 16th.
- */
-export const shouldShowJulyHoldNotice = (): boolean => {
-  const today = new Date();
-  const JULY = 6; // zero-based month index
-  return today.getMonth() === JULY && today.getDate() <= 15;
 };
 
 export const filterVendorPaymentProjects = (projects: string[]): string[] => {

--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -242,7 +242,7 @@ export const REMINDER_ITEMS: ReminderItem[] = [
   {
     title: "Submission Deadline:",
     content:
-      `Please log your hours and submit your payment on the same day you work. To ensure accuracy, review your "Submission History" regularly. If you need to correct your hours for a specific day, you must delete the incorrect entry and resubmit the correct hours for that day.\nAll submissions must be reviewed and finalized by the 5th of each month. On the 6th, all entries from the previous month will be automatically submitted for payment processing.\nIf you missed the monthly submission deadline, please contact the finance team: finance@teachinglab.org`,
+      `Please log your hours and submit your payment on the same day you work. To ensure accuracy, review your "Submission History" regularly. If you need to correct your hours for a specific day, you must delete the incorrect entry and resubmit the correct hours for that day.\nAll submissions must be reviewed and finalized by the 2nd of each month. On the 3rd, all entries from the previous month will be automatically submitted for payment processing.\nIf you missed the monthly submission deadline, please contact the finance team: finance@teachinglab.org`,
   },
  
 ];

--- a/app/components/vendor-payment-form/utils.tsx
+++ b/app/components/vendor-payment-form/utils.tsx
@@ -48,6 +48,14 @@ export type TaskDetails = {
   fixedHours?: number | null;
 };
 
+// Tasks that are always billed to the TL_Internal project; the project
+// selector is locked to TL_INTERNAL_PROJECT for these tasks
+export const TL_INTERNAL_PROJECT = "TL_Internal";
+export const TL_INTERNAL_ONLY_TASKS = [
+  "Onboarding",
+  "Learning Opportunities w/ Facilitation Team",
+];
+
 export const facilitationTaskOptions: TaskDetails[] = [
   {
     taskName: "Onboarding",
@@ -95,31 +103,10 @@ export const facilitationTaskOptions: TaskDetails[] = [
     fixedHours: 1,
   },
   {
-    taskName: "Second Facilitation of group Professional Learning courses",
-    "Tier 1": 100,
-    "Tier 2": null,
-    "Tier 3": null,
-    "Tier 4": null,
-    maxHours: {
-      "Tier 1": 6,
-      "Tier 2": null,
-      "Tier 3": null,
-      "Tier 4": null,
-    },
-  },
-  {
     taskName: "Mentoring of other Facilitation Contractors",
     "Tier 1": null,
     "Tier 2": 80,
     "Tier 3": 80,
-    "Tier 4": null,
-    maxHours: null,
-  },
-  {
-    taskName: "Tech/Support Facilitation of virtual group PL courses",
-    "Tier 1": 50,
-    "Tier 2": 50,
-    "Tier 3": 50,
     "Tier 4": null,
     maxHours: null,
   },
@@ -132,7 +119,7 @@ export const facilitationTaskOptions: TaskDetails[] = [
     maxHours: null,
   },
   {
-    taskName: "Content Training: Training to internalize the content of PL courses, curricula, or coaching framework. ",
+    taskName: "Content Training",
     "Tier 1": 50,
     "Tier 2": 50,
     "Tier 3": 50,
@@ -140,7 +127,7 @@ export const facilitationTaskOptions: TaskDetails[] = [
     maxHours: null,
   },
   {
-    taskName: "Learning Opportunities: Quarterly Paid Office Hours, Book Clubs, Observations, Kick Offs, etc.",
+    taskName: "Learning Opportunities w/ Facilitation Team",
     "Tier 1": 50,
     "Tier 2": 50,
     "Tier 3": 50,
@@ -222,14 +209,6 @@ export const dataEvaluationTaskOptions: TaskDetails[] = [
   {
     taskName: "Data Evaluation",
     "Tier 1": 27,
-    "Tier 2": null,
-    "Tier 3": null,
-    "Tier 4": null,
-    maxHours: null,
-  },
-  {
-    taskName: "Analysis, Visualization & Interpretation",
-    "Tier 1": 30,
     "Tier 2": null,
     "Tier 3": null,
     "Tier 4": null,

--- a/app/components/vendor-payment-form/vendor-payment-form.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-form.tsx
@@ -190,7 +190,7 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
                 <h1 className="font-bold text-3xl">Project Consultant Payment Form</h1>
                 <p className="text-white">This form is intended for contractors serving as coaches, facilitators, content developers and designers, and data evaluation consultants. Once submitted, it will be sent to the invoicing system at month-end for CPM approval and payment processing.</p>
                <p className="text-white">FY27 Facilitation Payment Guide:<br/>
-                Please review the <a href="https://docs.google.com/document/d/1qxZ8BClhZgaj1Ol1p1Dc5EfrIzmBtiiAYNz2I9CogW8/edit?tab=t.0#heading=h.afbcr7vh5ok3" target="_blank" rel="noopener noreferrer" style={{ textDecoration: "underline" }}>FY26 Facilitation Payment Guide</a> for detailed information about payment processes and term definitions.</p>
+                Please review the <a href="https://docs.google.com/document/d/1qxZ8BClhZgaj1Ol1p1Dc5EfrIzmBtiiAYNz2I9CogW8/edit?tab=t.0#heading=h.afbcr7vh5ok3" target="_blank" rel="noopener noreferrer" style={{ textDecoration: "underline" }}>FY27 Facilitation Payment Guide</a> for detailed information about payment processes and term definitions.</p>
               </div>
 
               <div className="mb-4">

--- a/app/components/vendor-payment-form/vendor-payment-form.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-form.tsx
@@ -1,17 +1,15 @@
 import { Button, Notification, Tabs } from "@mantine/core";
 import { DateInput } from "@mantine/dates";
 import { useFetcher, useNavigate, useLoaderData } from "@remix-run/react";
-import { IconCheck, IconInfoCircle, IconX } from "@tabler/icons-react";
+import { IconCheck, IconX } from "@tabler/icons-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { CoachFacilitatorDetails } from "~/domains/coachFacilitator/repository";
 import { Reminders } from "../weekly-project-log/reminders";
 import { PaymentHistory } from "./payment-history/payment-history";
 import {
-  getDefaultVendorPaymentDate,
   parseStoredTask,
   REMINDER_ITEMS,
   shouldExcludeVendorPaymentDate,
-  shouldShowJulyHoldNotice,
 } from "./utils";
 import { VendorPaymentWidget } from "./vendor-payment-widget";
 import { loader } from "~/routes/vendor-payment-form";
@@ -29,9 +27,7 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
   const [isValidated, setIsValidated] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [workDate, setWorkDate] = useState<Date | null>(
-    getDefaultVendorPaymentDate()
-  );
+  const [workDate, setWorkDate] = useState<Date | null>(new Date());
   const [activeTab, setActiveTab] = useState("new");
   const [vendorPaymentEntries, setVendorPaymentEntries] = useState([
     {
@@ -204,17 +200,6 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
                   excludeDate={shouldExcludeVendorPaymentDate}
                   error={isValidated === true && !workDate ? "Date is required" : null}
                 />
-                {shouldShowJulyHoldNotice() && (
-                  <Notification
-                    icon={<IconInfoCircle size={20} />}
-                    color="yellow"
-                    title="July submissions on hold"
-                    withCloseButton={false}
-                    className="mt-2"
-                  >
-                    Please hold off on submitting July entries until July 16.
-                  </Notification>
-                )}
               </div>
 
               <VendorPaymentWidget

--- a/app/components/vendor-payment-form/vendor-payment-form.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-form.tsx
@@ -189,8 +189,8 @@ export const VendorPaymentForm = ({ cfDetails }: { cfDetails: CoachFacilitatorDe
               <div className="flex flex-col gap-2">
                 <h1 className="font-bold text-3xl">Project Consultant Payment Form</h1>
                 <p className="text-white">This form is intended for contractors serving as coaches, facilitators, content developers and designers, and data evaluation consultants. Once submitted, it will be sent to the invoicing system at month-end for CPM approval and payment processing.</p>
-               <p className="text-white">FY26 Facilitation Payment Guide:<br/>
-                Please review the <a href="https://docs.google.com/document/d/1N8FOqieDQWt0sGJH1pFqyMnWv4Rb4ykmuvlhBShWrfA/edit?tab=t.0" target="_blank" rel="noopener noreferrer" style={{ textDecoration: "underline" }}>FY26 Facilitation Payment Guide</a> for detailed information about payment processes and term definitions.</p>
+               <p className="text-white">FY27 Facilitation Payment Guide:<br/>
+                Please review the <a href="https://docs.google.com/document/d/1qxZ8BClhZgaj1Ol1p1Dc5EfrIzmBtiiAYNz2I9CogW8/edit?tab=t.0#heading=h.afbcr7vh5ok3" target="_blank" rel="noopener noreferrer" style={{ textDecoration: "underline" }}>FY26 Facilitation Payment Guide</a> for detailed information about payment processes and term definitions.</p>
               </div>
 
               <div className="mb-4">

--- a/app/components/vendor-payment-form/vendor-payment-widget.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-widget.tsx
@@ -20,6 +20,8 @@ import {
   presentationDesignTaskOptions,
   StoredTask,
   TaskDetails,
+  TL_INTERNAL_ONLY_TASKS,
+  TL_INTERNAL_PROJECT,
 } from "./utils";
 
 type VendorPaymentRow = {
@@ -194,6 +196,8 @@ export const VendorPaymentWidget = ({
       )}
       renderRow={(row, _index, { canDelete, updateRow, deleteRow }) => {
         const taskData = parseStoredTask(row.task);
+        const isInternalOnlyTask =
+          !!taskData && TL_INTERNAL_ONLY_TASKS.includes(taskData.taskName);
         return (
         <div className="flex flex-col gap-2">
           <div className={gridClass(canDelete)}>
@@ -204,6 +208,13 @@ export const VendorPaymentWidget = ({
                 const update: Partial<VendorPaymentRow> = { task: value || "" };
                 if (parsed?.fixedHours != null) {
                   update.workHours = parsed.fixedHours.toString();
+                }
+                if (parsed && TL_INTERNAL_ONLY_TASKS.includes(parsed.taskName)) {
+                  update.project = TL_INTERNAL_PROJECT;
+                } else if (row.project === TL_INTERNAL_PROJECT) {
+                  // Clear the locked project when switching away from a
+                  // TL_Internal-only task
+                  update.project = "";
                 }
                 updateRow(update);
               }}
@@ -221,7 +232,12 @@ export const VendorPaymentWidget = ({
               value={row.project || null}
               onChange={(value) => updateRow({ project: value || "" })}
               placeholder="Select a project"
-              data={projectOptions}
+              data={
+                isInternalOnlyTask
+                  ? [{ value: TL_INTERNAL_PROJECT, label: TL_INTERNAL_PROJECT }]
+                  : projectOptions
+              }
+              disabled={isInternalOnlyTask}
               searchable
               error={
                 isValidated === false && !row.project

--- a/app/components/vendor-payment-form/vendor-payment-widget.tsx
+++ b/app/components/vendor-payment-form/vendor-payment-widget.tsx
@@ -88,6 +88,7 @@ export const VendorPaymentWidget = ({
               maxHours:
                 task.maxHours?.[tier.value as "Tier 1" | "Tier 2" | "Tier 3" | "Tier 4"] ||
                 null,
+              fixedHours: task.fixedHours ?? null,
             });
           }
         });
@@ -101,6 +102,7 @@ export const VendorPaymentWidget = ({
               maxHours:
                 task.maxHours?.[tier.value as "Tier 1" | "Tier 2" | "Tier 3" | "Tier 4"] ||
                 null,
+              fixedHours: task.fixedHours ?? null,
             });
           }
         });
@@ -114,6 +116,7 @@ export const VendorPaymentWidget = ({
               maxHours:
                 task.maxHours?.[tier.value as "Tier 1" | "Tier 2" | "Tier 3" | "Tier 4"] ||
                 null,
+              fixedHours: task.fixedHours ?? null,
             });
           }
         });
@@ -127,6 +130,7 @@ export const VendorPaymentWidget = ({
               maxHours:
                 task.maxHours?.[tier.value as "Tier 1" | "Tier 2" | "Tier 3" | "Tier 4"] ||
                 null,
+              fixedHours: task.fixedHours ?? null,
             });
           }
         });
@@ -140,6 +144,7 @@ export const VendorPaymentWidget = ({
               maxHours:
                 task.maxHours?.[tier.value as "Tier 1" | "Tier 2" | "Tier 3" | "Tier 4"] ||
                 null,
+              fixedHours: task.fixedHours ?? null,
             });
           }
         });
@@ -153,6 +158,7 @@ export const VendorPaymentWidget = ({
               maxHours:
                 task.maxHours?.[tier.value as "Tier 1" | "Tier 2" | "Tier 3" | "Tier 4"] ||
                 null,
+              fixedHours: task.fixedHours ?? null,
             });
           }
         });
@@ -193,7 +199,14 @@ export const VendorPaymentWidget = ({
           <div className={gridClass(canDelete)}>
             <Select
               value={row.task || null}
-              onChange={(value) => updateRow({ task: value || "" })}
+              onChange={(value) => {
+                const parsed = value ? JSON.parse(value) : null;
+                const update: Partial<VendorPaymentRow> = { task: value || "" };
+                if (parsed?.fixedHours != null) {
+                  update.workHours = parsed.fixedHours.toString();
+                }
+                updateRow(update);
+              }}
               placeholder="Select a task"
               data={listOfAvailableTasks.map((option) => ({
                 value: JSON.stringify(option),
@@ -224,6 +237,7 @@ export const VendorPaymentWidget = ({
               placeholder="Enter work hours"
               max={taskData?.maxHours ?? undefined}
               min={0}
+              readOnly={taskData?.fixedHours != null}
               error={
                 isValidated === false &&
                 (!row.workHours || Number(row.workHours) === 0)

--- a/app/domains/coachFacilitator/repository.ts
+++ b/app/domains/coachFacilitator/repository.ts
@@ -22,39 +22,66 @@ export function coachFacilitatorRepository(): CoachFacilitatorRepository {
   return {
     fetchCoachFacilitatorDetails: async (email: string) => {
       try {
+        //NOTE: Not using Monday API filtering by email because it doesn't support filtering mirror columns (lookup42)
+        const itemFields = `
+          items {
+            name
+            column_values(
+              ids: ["lookup42", "lookup_mkr45vx5", "color_mkr4h6fc", "color_mkr4ss46", "color_mkr4a2k5", "color_mkr4rtg", "color_mkrd296b", "boolean_mm40wz9b"]
+            ) {
+              id
+              text
+              ... on MirrorValue {
+                display_value
+                id
+              }
+              ... on CheckboxValue {
+                checked
+              }
+            }
+          }`;
+
         // Query to fetch coach/facilitator details from Monday board
         const query = `{
           boards(ids: 4084773997) {
             groups(ids: ["1680715772_coach_facilitator_d"]) {
               items_page(limit: 500) {
-                items {
-                  name
-                  column_values(
-                    ids: ["lookup42", "lookup_mkr45vx5", "color_mkr4h6fc", "color_mkr4ss46", "color_mkr4a2k5", "color_mkr4rtg", "color_mkrd296b"]
-                  ) {
-                    id
-                    text
-                    ... on MirrorValue {
-                      display_value
-                      id
-                    }
-                  }
-                }
+                cursor
+                ${itemFields}
               }
             }
           }
         }`;
 
-        const result = await fetchMondayData(query);
-        const items = result.data.boards[0].groups[0].items_page.items;
+        const findByEmail = (items: any[]) =>
+          items.find((item: any) => {
+            // Only accounts marked "Active in FY27" are considered
+            const isActive = item.column_values.find(
+              (col: any) => col.id === "boolean_mm40wz9b"
+            )?.checked === true;
+            const emailValuefromMonday = item.column_values.find(
+              (col: any) => col.id === "lookup42"
+            )?.display_value;
+            return isActive && compareTwoStrings(emailValuefromMonday || "", email);
+          });
 
-        // Find the matching item by email
-        const matchingItem = items.find((item: any) => {
-          const emailValuefromMonday = item.column_values.find(
-            (col: any) => col.id === "lookup42"
-          )?.display_value;
-          return compareTwoStrings(emailValuefromMonday || "", email);
-        });
+        const result = await fetchMondayData(query);
+        const firstPage = result.data.boards[0].groups[0].items_page;
+        let matchingItem = findByEmail(firstPage.items);
+        let cursor: string | null = firstPage.cursor;
+
+        // Page through the rest of the group until a match is found
+        while (!matchingItem && cursor) {
+          const cursorQuery = `{
+            next_items_page(limit: 500, cursor: "${cursor}") {
+              cursor
+              ${itemFields}
+            }
+          }`;
+          const nextResult = await fetchMondayData(cursorQuery);
+          matchingItem = findByEmail(nextResult.data.next_items_page.items);
+          cursor = nextResult.data.next_items_page.cursor;
+        }
 
         if (!matchingItem) {
           return { data: null, error: null };

--- a/supabase/functions/send-vendor-payment-summaries/docx-generator.ts
+++ b/supabase/functions/send-vendor-payment-summaries/docx-generator.ts
@@ -1,0 +1,173 @@
+import {
+  AlignmentType,
+  Document,
+  HeadingLevel,
+  Packer,
+  Paragraph,
+  ShadingType,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  WidthType,
+} from "https://esm.sh/docx@8.5.0";
+import { PersonProjectSummary } from "./types.ts";
+
+function formatMoney(amount: number): string {
+  return new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+function formatDateOnlyNoTz(input: string): string {
+  const datePart = input.split("T")[0];
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return input;
+  const [y, m, d] = datePart.split("-");
+  const monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  const monthName = monthNames[Number(m) - 1] || m;
+  return `${monthName} ${Number(d)}, ${y}`;
+}
+
+function isContentDevelopmentTask(taskName: string): boolean {
+  return taskName.trim().replace(/^task\s*[–-]\s*/i, "").trim().toLowerCase() === "content development";
+}
+
+export async function generateProjectDocx(
+  projectName: string,
+  personSummary: PersonProjectSummary,
+  logId: number | null,
+): Promise<Uint8Array> {
+  console.log(`Starting DOCX generation for ${personSummary.cf_email} on project: ${projectName}`);
+
+  try {
+    const currentDate = new Date();
+    const previousMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
+    const reportMonth = previousMonth.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+    const lastDayOfPreviousMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 0);
+    const invoiceDate = lastDayOfPreviousMonth.toLocaleDateString();
+    const invoiceNumber = logId ? logId.toString() : Date.now().toString();
+
+    const sortedEntries = [...personSummary.detailedEntries].sort((a, b) => {
+      const dateA = (a.submission_date ?? "").split("T")[0];
+      const dateB = (b.submission_date ?? "").split("T")[0];
+      return dateA.localeCompare(dateB);
+    });
+
+    const totals = personSummary.detailedEntries.reduce(
+      (acc, entry) => {
+        const pay = typeof entry.entry_pay === "number" && !Number.isNaN(entry.entry_pay) ? entry.entry_pay : 0;
+        if (isContentDevelopmentTask(entry.task_name)) {
+          acc.contentDevelopment += pay;
+        } else {
+          acc.otherServices += pay;
+        }
+        return acc;
+      },
+      { contentDevelopment: 0, otherServices: 0 },
+    );
+    const showContentDevelopmentBreakdown = totals.contentDevelopment > 0;
+
+    const headerRow = new TableRow({
+      tableHeader: true,
+      children: [
+        { label: "Date", align: AlignmentType.LEFT },
+        { label: "Task", align: AlignmentType.LEFT },
+        { label: "Note", align: AlignmentType.LEFT },
+        { label: "Hours", align: AlignmentType.RIGHT },
+        { label: "Rate", align: AlignmentType.RIGHT },
+        { label: "Subtotal", align: AlignmentType.RIGHT },
+      ].map(({ label, align }) =>
+        new TableCell({
+          shading: { fill: "F2F2F2", type: ShadingType.CLEAR, color: "auto" },
+          children: [
+            new Paragraph({
+              alignment: align,
+              children: [new TextRun({ text: label, bold: true, size: 20 })],
+            }),
+          ],
+        })
+      ),
+    });
+
+    const entryRows = sortedEntries.map((entry) => {
+      let dateDisplay = "";
+      if (entry.submission_date) {
+        dateDisplay = formatDateOnlyNoTz(entry.submission_date);
+      } else if (personSummary.submission_date) {
+        dateDisplay = formatDateOnlyNoTz(personSummary.submission_date);
+      }
+
+      return new TableRow({
+        children: [
+          new TableCell({ children: [new Paragraph({ children: [new TextRun({ text: dateDisplay, size: 18 })] })] }),
+          new TableCell({ children: [new Paragraph({ children: [new TextRun({ text: entry.task_name, size: 18 })] })] }),
+          new TableCell({ children: [new Paragraph({ children: [new TextRun({ text: entry.note ?? "", size: 18 })] })] }),
+          new TableCell({ children: [new Paragraph({ alignment: AlignmentType.RIGHT, children: [new TextRun({ text: entry.work_hours.toString(), size: 18 })] })] }),
+          new TableCell({ children: [new Paragraph({ alignment: AlignmentType.RIGHT, children: [new TextRun({ text: `$${entry.rate.toFixed(2)}`, size: 18 })] })] }),
+          new TableCell({ children: [new Paragraph({ alignment: AlignmentType.RIGHT, children: [new TextRun({ text: `$${entry.entry_pay.toFixed(2)}`, size: 18 })] })] }),
+        ],
+      });
+    });
+
+    const totalsParagraphs: Paragraph[] = [];
+    if (showContentDevelopmentBreakdown) {
+      totalsParagraphs.push(
+        new Paragraph({
+          alignment: AlignmentType.RIGHT,
+          children: [new TextRun({ text: `Total Content Development: $ ${formatMoney(totals.contentDevelopment)}`, size: 22 })],
+        }),
+        new Paragraph({
+          alignment: AlignmentType.RIGHT,
+          children: [new TextRun({ text: `Total Other Services: $ ${formatMoney(totals.otherServices)}`, size: 22 })],
+        }),
+      );
+    }
+    totalsParagraphs.push(
+      new Paragraph({
+        alignment: AlignmentType.RIGHT,
+        children: [new TextRun({ text: `Total Payment: $ ${formatMoney(personSummary.totalPayForProject)}`, bold: true, size: 26 })],
+      }),
+    );
+
+    const doc = new Document({
+      sections: [{
+        children: [
+          new Paragraph({
+            heading: HeadingLevel.HEADING_1,
+            children: [new TextRun({ text: `${personSummary.cf_name} - Payment Summary`, bold: true })],
+          }),
+          new Paragraph({
+            heading: HeadingLevel.HEADING_2,
+            children: [new TextRun({ text: `Project: ${projectName}`, bold: true })],
+          }),
+          new Paragraph({ children: [new TextRun({ text: `Invoice #: ${invoiceNumber}` })] }),
+          new Paragraph({ children: [new TextRun({ text: `Report Month: ${reportMonth}` })] }),
+          new Paragraph({ children: [new TextRun({ text: `Invoice Date: ${invoiceDate}` })] }),
+          new Paragraph({ children: [new TextRun({ text: "Bill to: Teaching Lab" })] }),
+          new Paragraph({ children: [new TextRun({ text: `Coach/Facilitator: ${personSummary.cf_name} (${personSummary.cf_email})` })] }),
+          new Paragraph({ children: [new TextRun({ text: `Tier: ${personSummary.cf_tier}` })] }),
+          new Paragraph({ text: "" }),
+          new Table({
+            width: { size: 100, type: WidthType.PERCENTAGE },
+            rows: [headerRow, ...entryRows],
+          }),
+          new Paragraph({ text: "" }),
+          ...totalsParagraphs,
+          new Paragraph({ text: "" }),
+          new Paragraph({ children: [new TextRun({ text: "This is an automated payment summary from Teaching Lab.", color: "808080", size: 16 })] }),
+          new Paragraph({ children: [new TextRun({ text: "Please contact accountspayable@teachinglab.org for any questions.", color: "808080", size: 16 })] }),
+        ],
+      }],
+    });
+
+    const blob = await Packer.toBlob(doc);
+    const arrayBuffer = await blob.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+    console.log(`DOCX generated successfully for ${personSummary.cf_email} / ${projectName}, size: ${bytes.length} bytes`);
+    return bytes;
+  } catch (error) {
+    console.error(`Error generating DOCX for ${personSummary.cf_email} on project ${projectName}:`, error);
+    throw error;
+  }
+}

--- a/supabase/functions/send-vendor-payment-summaries/docx-generator.ts
+++ b/supabase/functions/send-vendor-payment-summaries/docx-generator.ts
@@ -1,7 +1,6 @@
 import {
   AlignmentType,
   Document,
-  HeadingLevel,
   Packer,
   Paragraph,
   ShadingType,
@@ -32,6 +31,10 @@ function formatDateOnlyNoTz(input: string): string {
 function isContentDevelopmentTask(taskName: string): boolean {
   return taskName.trim().replace(/^task\s*[–-]\s*/i, "").trim().toLowerCase() === "content development";
 }
+
+// A4 content width with 1" margins: (8.27 - 2) * 1440 = 9029 DXA
+// Column proportions match the PDF: 15% / 25% / 25% / 12% / 11% / 12%
+const COL_WIDTHS_DXA = [1354, 2257, 2257, 1083, 993, 1083];
 
 export async function generateProjectDocx(
   projectName: string,
@@ -68,22 +71,25 @@ export async function generateProjectDocx(
     );
     const showContentDevelopmentBreakdown = totals.contentDevelopment > 0;
 
+    const headerCols = [
+      { label: "Date",     align: AlignmentType.LEFT },
+      { label: "Task",     align: AlignmentType.LEFT },
+      { label: "Note",     align: AlignmentType.LEFT },
+      { label: "Hours",    align: AlignmentType.RIGHT },
+      { label: "Rate",     align: AlignmentType.RIGHT },
+      { label: "Subtotal", align: AlignmentType.RIGHT },
+    ];
+
     const headerRow = new TableRow({
       tableHeader: true,
-      children: [
-        { label: "Date", align: AlignmentType.LEFT },
-        { label: "Task", align: AlignmentType.LEFT },
-        { label: "Note", align: AlignmentType.LEFT },
-        { label: "Hours", align: AlignmentType.RIGHT },
-        { label: "Rate", align: AlignmentType.RIGHT },
-        { label: "Subtotal", align: AlignmentType.RIGHT },
-      ].map(({ label, align }) =>
+      children: headerCols.map(({ label, align }, i) =>
         new TableCell({
+          width: { size: COL_WIDTHS_DXA[i], type: WidthType.DXA },
           shading: { fill: "F2F2F2", type: ShadingType.CLEAR, color: "auto" },
           children: [
             new Paragraph({
               alignment: align,
-              children: [new TextRun({ text: label, bold: true, size: 20 })],
+              children: [new TextRun({ text: label, bold: true, size: 22, color: "000000" })],
             }),
           ],
         })
@@ -98,14 +104,20 @@ export async function generateProjectDocx(
         dateDisplay = formatDateOnlyNoTz(personSummary.submission_date);
       }
 
+      const cell = (text: string, align = AlignmentType.LEFT, colIndex: number) =>
+        new TableCell({
+          width: { size: COL_WIDTHS_DXA[colIndex], type: WidthType.DXA },
+          children: [new Paragraph({ alignment: align, children: [new TextRun({ text, size: 20, color: "000000" })] })],
+        });
+
       return new TableRow({
         children: [
-          new TableCell({ children: [new Paragraph({ children: [new TextRun({ text: dateDisplay, size: 18 })] })] }),
-          new TableCell({ children: [new Paragraph({ children: [new TextRun({ text: entry.task_name, size: 18 })] })] }),
-          new TableCell({ children: [new Paragraph({ children: [new TextRun({ text: entry.note ?? "", size: 18 })] })] }),
-          new TableCell({ children: [new Paragraph({ alignment: AlignmentType.RIGHT, children: [new TextRun({ text: entry.work_hours.toString(), size: 18 })] })] }),
-          new TableCell({ children: [new Paragraph({ alignment: AlignmentType.RIGHT, children: [new TextRun({ text: `$${entry.rate.toFixed(2)}`, size: 18 })] })] }),
-          new TableCell({ children: [new Paragraph({ alignment: AlignmentType.RIGHT, children: [new TextRun({ text: `$${entry.entry_pay.toFixed(2)}`, size: 18 })] })] }),
+          cell(dateDisplay,                       AlignmentType.LEFT,  0),
+          cell(entry.task_name,                   AlignmentType.LEFT,  1),
+          cell(entry.note ?? "",                  AlignmentType.LEFT,  2),
+          cell(entry.work_hours.toString(),        AlignmentType.RIGHT, 3),
+          cell(`$${entry.rate.toFixed(2)}`,        AlignmentType.RIGHT, 4),
+          cell(`$${entry.entry_pay.toFixed(2)}`,   AlignmentType.RIGHT, 5),
         ],
       });
     });
@@ -115,48 +127,50 @@ export async function generateProjectDocx(
       totalsParagraphs.push(
         new Paragraph({
           alignment: AlignmentType.RIGHT,
-          children: [new TextRun({ text: `Total Content Development: $ ${formatMoney(totals.contentDevelopment)}`, size: 22 })],
+          children: [new TextRun({ text: `Total Content Development: $ ${formatMoney(totals.contentDevelopment)}`, size: 24, color: "000000" })],
         }),
         new Paragraph({
           alignment: AlignmentType.RIGHT,
-          children: [new TextRun({ text: `Total Other Services: $ ${formatMoney(totals.otherServices)}`, size: 22 })],
+          children: [new TextRun({ text: `Total Other Services: $ ${formatMoney(totals.otherServices)}`, size: 24, color: "000000" })],
         }),
       );
     }
     totalsParagraphs.push(
       new Paragraph({
         alignment: AlignmentType.RIGHT,
-        children: [new TextRun({ text: `Total Payment: $ ${formatMoney(personSummary.totalPayForProject)}`, bold: true, size: 26 })],
+        children: [new TextRun({ text: `Total Payment: $ ${formatMoney(personSummary.totalPayForProject)}`, bold: true, size: 28, color: "000000" })],
       }),
     );
 
     const doc = new Document({
       sections: [{
         children: [
+          // Title — plain bold paragraph, no Word heading style
           new Paragraph({
-            heading: HeadingLevel.HEADING_1,
-            children: [new TextRun({ text: `${personSummary.cf_name} - Payment Summary`, bold: true })],
+            spacing: { after: 160 },
+            children: [new TextRun({ text: `${personSummary.cf_name} - Payment Summary`, bold: true, size: 40, color: "000000" })],
           }),
           new Paragraph({
-            heading: HeadingLevel.HEADING_2,
-            children: [new TextRun({ text: `Project: ${projectName}`, bold: true })],
+            spacing: { after: 160 },
+            children: [new TextRun({ text: `Project: ${projectName}`, bold: true, size: 32, color: "000000" })],
           }),
-          new Paragraph({ children: [new TextRun({ text: `Invoice #: ${invoiceNumber}` })] }),
-          new Paragraph({ children: [new TextRun({ text: `Report Month: ${reportMonth}` })] }),
-          new Paragraph({ children: [new TextRun({ text: `Invoice Date: ${invoiceDate}` })] }),
-          new Paragraph({ children: [new TextRun({ text: "Bill to: Teaching Lab" })] }),
-          new Paragraph({ children: [new TextRun({ text: `Coach/Facilitator: ${personSummary.cf_name} (${personSummary.cf_email})` })] }),
-          new Paragraph({ children: [new TextRun({ text: `Tier: ${personSummary.cf_tier}` })] }),
+          new Paragraph({ spacing: { after: 100 }, children: [new TextRun({ text: `Invoice #: ${invoiceNumber}`, size: 24, color: "000000" })] }),
+          new Paragraph({ spacing: { after: 100 }, children: [new TextRun({ text: `Report Month: ${reportMonth}`, size: 24, color: "000000" })] }),
+          new Paragraph({ spacing: { after: 100 }, children: [new TextRun({ text: `Invoice Date: ${invoiceDate}`, size: 24, color: "000000" })] }),
+          new Paragraph({ spacing: { after: 100 }, children: [new TextRun({ text: "Bill to: Teaching Lab", size: 24, color: "000000" })] }),
+          new Paragraph({ spacing: { after: 100 }, children: [new TextRun({ text: `Coach/Facilitator: ${personSummary.cf_name} (${personSummary.cf_email})`, size: 24, color: "000000" })] }),
+          new Paragraph({ spacing: { after: 200 }, children: [new TextRun({ text: `Tier: ${personSummary.cf_tier}`, size: 24, color: "000000" })] }),
           new Paragraph({ text: "" }),
           new Table({
-            width: { size: 100, type: WidthType.PERCENTAGE },
+            width: { size: 9027, type: WidthType.DXA },
+            columnWidths: COL_WIDTHS_DXA,
             rows: [headerRow, ...entryRows],
           }),
           new Paragraph({ text: "" }),
           ...totalsParagraphs,
           new Paragraph({ text: "" }),
-          new Paragraph({ children: [new TextRun({ text: "This is an automated payment summary from Teaching Lab.", color: "808080", size: 16 })] }),
-          new Paragraph({ children: [new TextRun({ text: "Please contact accountspayable@teachinglab.org for any questions.", color: "808080", size: 16 })] }),
+          new Paragraph({ children: [new TextRun({ text: "This is an automated payment summary from Teaching Lab.", color: "808080", size: 18 })] }),
+          new Paragraph({ children: [new TextRun({ text: "Please contact accountspayable@teachinglab.org for any questions.", color: "808080", size: 18 })] }),
         ],
       }],
     });

--- a/supabase/functions/send-vendor-payment-summaries/index.ts
+++ b/supabase/functions/send-vendor-payment-summaries/index.ts
@@ -125,7 +125,7 @@ try {
         );
       }
 
-      // Get previous month (since this function runs on the 6th of each month to process previous month's data)
+      // Get previous month (since this function runs on the 3rd of each month to process previous month's data)
       const currentDate = new Date();
       const previousMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
       const previousMonthISO = previousMonth.toISOString();

--- a/supabase/functions/send-vendor-payment-summaries/index.ts
+++ b/supabase/functions/send-vendor-payment-summaries/index.ts
@@ -8,6 +8,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts"
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
 import { generateProjectPDF } from "./pdf-generator.ts";
+import { generateProjectDocx } from "./docx-generator.ts";
 import { sendProjectEmail } from "./utils.ts";
 import { PersonProjectSummary } from "./types.ts";
 
@@ -292,12 +293,18 @@ try {
           const pdf = await generateProjectPDF(projectName, personSummary, logId); // Pass person-specific summary
           console.log(`-- PDF generated successfully for ${personEmail}/${projectName}`);
 
+          // Generate editable DOCX for the contractor
+          console.log(`-- Generating DOCX for ${personEmail} on project ${projectName}`);
+          const docx = await generateProjectDocx(projectName, personSummary, logId);
+          console.log(`-- DOCX generated successfully for ${personEmail}/${projectName}`);
+
           // Send email to this person for this project
           console.log(`-- Sending email to ${personEmail} for project ${projectName}`);
           await sendProjectEmail(
             projectName,
             personSummary, // Pass the necessary summary details
             pdf,
+            docx,
           );
           console.log(`-- Email sent successfully to ${personEmail} for project ${projectName}`);
 

--- a/supabase/functions/send-vendor-payment-summaries/utils.ts
+++ b/supabase/functions/send-vendor-payment-summaries/utils.ts
@@ -11,25 +11,29 @@ export async function sendProjectEmail(
     projectName: string,
     personSummary: PersonProjectSummary, // Pass the person's summary object
     pdf: Uint8Array,
+    docx: Uint8Array,
   ): Promise<void> {
     const recipientEmail = ["yancheng.pan@teachinglab.org", "accountspayable@teachinglab.org", personSummary.cf_email];
     console.log(`Starting email sending for ${personSummary.cf_name} (${personSummary.cf_email}) on project: ${projectName}`);
     try {
       const supportEmail = Deno.env.get("SUPPORT_EMAIL") || "support@example.com";
-  
-      const pdfBase64 = (() => {
+
+      const toBase64 = (bytes: Uint8Array): string => {
         let binary = "";
         const chunkSize = 8192;
-        for (let i = 0; i < pdf.length; i += chunkSize) {
-          binary += String.fromCharCode(...pdf.subarray(i, i + chunkSize));
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+          binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
         }
         return btoa(binary);
-      })();
+      };
+
+      const pdfBase64 = toBase64(pdf);
+      const docxBase64 = toBase64(docx);
       console.log(`PDF Base64 length: ${pdfBase64.length}`);
+      console.log(`DOCX Base64 length: ${docxBase64.length}`);
       const reportMonthYear = new Date().toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
-      // Make filename person-specific
-      const filename = `TeachingLab-PaymentSummary-${personSummary.cf_name.replace(/\s+/g, '')}-${projectName.replace(/\s+/g, '_')}-${reportMonthYear}.pdf`;
-      
+      const baseName = `TeachingLab-PaymentSummary-${personSummary.cf_name.replace(/\s+/g, '')}-${projectName.replace(/\s+/g, '_')}-${reportMonthYear}`;
+
       const emailData = {
         from: "Teaching Lab Payments <yancheng.pan@teachinglab.org>", // Use sender name
         to: recipientEmail,
@@ -39,14 +43,22 @@ export async function sendProjectEmail(
           <p>Hello,</p>
           <p>Please find attached your payment summary for project <strong>${projectName}</strong> for the period ending ${reportMonthYear}.</p>
           <p>Total payment for the project member in this period: <strong>$${personSummary.totalPayForProject.toFixed(2)}</strong></p>
+          <p>Two versions of the invoice are attached: a PDF for your records and an editable Word document in case you need to make any corrections.</p>
           <p>If you have any questions, please contact ${supportEmail}.</p>
           <p>Best regards,<br>Teaching Lab FinanceTeam</p>
         `,
-        attachments: [{
-          filename: filename,
-          content: pdfBase64,
-          contentType: 'application/pdf'
-        }]
+        attachments: [
+          {
+            filename: `${baseName}.pdf`,
+            content: pdfBase64,
+            contentType: 'application/pdf',
+          },
+          {
+            filename: `${baseName}.docx`,
+            content: docxBase64,
+            contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          },
+        ]
       };
   
       console.log(`Sending email to ${recipientEmail} for ${projectName}...`);

--- a/supabase/functions/send-vendor-payment-summaries/utils.ts
+++ b/supabase/functions/send-vendor-payment-summaries/utils.ts
@@ -4,6 +4,9 @@ import { PersonProjectSummary } from "./types.ts";
 // Initialize Resend client
 const resend = new Resend(Deno.env.get("RESEND_API_KEY")); // Env var dones't work for localhost testing
 
+const escHtml = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
 
 
 // --- Updated Email Sending Function ---
@@ -41,10 +44,10 @@ export async function sendProjectEmail(
         html: `
           <h1>Teaching Lab - Payment Summary</h1>
           <p>Hello,</p>
-          <p>Please find attached your payment summary for project <strong>${projectName}</strong> for the period ending ${reportMonthYear}.</p>
+          <p>Please find attached your payment summary for project <strong>${escHtml(projectName)}</strong> for the period ending ${escHtml(reportMonthYear)}.</p>
           <p>Total payment for the project member in this period: <strong>$${personSummary.totalPayForProject.toFixed(2)}</strong></p>
           <p>Two versions of the invoice are attached: a PDF for your records and an editable Word document in case you need to make any corrections.</p>
-          <p>If you have any questions, please contact ${supportEmail}.</p>
+          <p>If you have any questions, please contact ${escHtml(supportEmail)}.</p>
           <p>Best regards,<br>Teaching Lab FinanceTeam</p>
         `,
         attachments: [

--- a/supabase/functions/send-vendor-payment-summaries/utils.ts
+++ b/supabase/functions/send-vendor-payment-summaries/utils.ts
@@ -12,7 +12,7 @@ export async function sendProjectEmail(
     personSummary: PersonProjectSummary, // Pass the person's summary object
     pdf: Uint8Array,
   ): Promise<void> {
-    const recipientEmail = ["yancheng.pan@teachinglab.org", "accountspayable@teachinglab.org"];
+    const recipientEmail = ["yancheng.pan@teachinglab.org", "accountspayable@teachinglab.org", personSummary.cf_email];
     console.log(`Starting email sending for ${personSummary.cf_name} (${personSummary.cf_email}) on project: ${projectName}`);
     try {
       const supportEmail = Deno.env.get("SUPPORT_EMAIL") || "support@example.com";

--- a/supabase/functions/send-vendor-payment-summaries/utils.ts
+++ b/supabase/functions/send-vendor-payment-summaries/utils.ts
@@ -16,7 +16,8 @@ export async function sendProjectEmail(
     pdf: Uint8Array,
     docx: Uint8Array,
   ): Promise<void> {
-    const recipientEmail = ["yancheng.pan@teachinglab.org", "accountspayable@teachinglab.org", personSummary.cf_email];
+    const recipientEmail = ["yancheng.pan@teachinglab.org", "accountspayable@teachinglab.org"];
+    if (personSummary.cf_email) recipientEmail.push(personSummary.cf_email);
     console.log(`Starting email sending for ${personSummary.cf_name} (${personSummary.cf_email}) on project: ${projectName}`);
     try {
       const supportEmail = Deno.env.get("SUPPORT_EMAIL") || "support@example.com";


### PR DESCRIPTION
Closes #139

## Summary

### Invoice Email Changes
- Contractor now receives the invoice email (their `cf_email` is added to the recipient list alongside the internal recipients)
- Both a **PDF** and an editable **Word document (.docx)** are attached to every invoice email so contractors can make corrections if any details are wrong

### Email Trigger Schedule
- Updated monthly cron job from the **6th** to the **3rd** of each month
- Note: the cron schedule itself must be updated in the Supabase Dashboard (Edge Functions → send-vendor-payment-summaries → Schedule) to `0 0 3 * *`

### Vendor Payment Form — Task Dropdown Changes
- **Removed** the following tasks:
  - Lead coaching activities: 1-1 coaching sessions, micro group PL, or walkthrough
  - Lead coaching preparation & follow-up: internalization or preparation for coaching sessions; follow-up activities; completion of Coaching Action Plans and Coaching Log
  - Lead Facilitation of group Professional Learning course
  - Tech/Support Facilitation of group Professional Learning courses
- **Renamed** "Site Context + Support: Meetings and collaborations..." → **Collaboration** (rate unchanged at $50/hr)
- **Added** 4 new day-rate flat-fee tasks based on the updated compensation table:

  | Task | Tier 1 | Tier 2 | Tier 3 |
  |------|--------|--------|--------|
  | 1/3 Day: ~2hrs C/F | $350 | $370 | $400 |
  | 1/2 Day: ~3hrs C/F | $500 | $540 | $585 |
  | Full Day: ~6hrs C/F | $1,000 | $1,080 | $1,170 |
  | Extended Day: 6hrs+ C/F | $1,150 | $1,250 | $1,320 |

### Flat-Fee Hour Locking
- The new day-rate tasks and **Onboarding** are now treated as flat fees: selecting one auto-populates work hours to `1` and locks the input so contractors cannot change it. The total pay equals the tier rate directly.

## Test plan
- [ ] Trigger `send-vendor-payment-summaries` edge function and confirm contractor receives email with both PDF and .docx attachments
- [ ] Verify .docx opens cleanly in Word with correct formatting, column widths, and line spacing
- [ ] Open vendor payment form and confirm the 4 removed tasks no longer appear in the dropdown
- [ ] Confirm "Collaboration" appears in place of "Site Context + Support"
- [ ] Select each new day-rate task and confirm work hours auto-fills to 1, is locked, and total pay matches the tier rate
- [ ] Confirm Onboarding also locks hours to 1 at $500
- [ ] Update cron schedule in Supabase Dashboard to `0 0 3 * *`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 updates (2026-07-15, commit 4db58b97)

### Vendor Payment Form — Task Dropdown Changes
- **Removed** the following tasks:
  - Second Facilitation of group Professional Learning courses
  - Tech/Support Facilitation of virtual group PL courses
  - Analysis, Visualization & Interpretation (Data Evaluation list)
- **Renamed:**
  - "Content Training: Training to internalize the content of PL courses, curricula, or coaching framework." → **Content Training**
  - "Learning Opportunities: Quarterly Paid Office Hours, Book Clubs, Observations, Kick Offs, etc." → **Learning Opportunities w/ Facilitation Team**

### TL_Internal Project Lock
- **Onboarding** and **Learning Opportunities w/ Facilitation Team** are now hard-coded to the **TL_Internal** project: selecting either task auto-fills the Project field with `TL_Internal` and disables the dropdown (this was a common monthly user error requiring manual fixes)
- Switching from one of these tasks to a regular task clears the locked project value
- Internal-only tasks are defined in `TL_INTERNAL_ONLY_TASKS` in `vendor-payment-form/utils.tsx` for easy future additions

## Test plan (round 2)
- [ ] Confirm the 3 removed tasks no longer appear in the dropdown (preview env)
- [ ] Confirm renamed tasks show as "Content Training" and "Learning Opportunities w/ Facilitation Team"
- [ ] Select Onboarding → Project auto-fills to TL_Internal and is locked
- [ ] Select Learning Opportunities w/ Facilitation Team → Project auto-fills to TL_Internal and is locked
- [ ] Switch from Onboarding to another task → Project field clears


---

## Round 3 updates (2026-07-15, commit a84d97ac)

### Submission Hold Removed
- Removed the "July submissions on hold" notice and the temporary date lock that blocked current-month entries until the 16th
- Date picker now always allows current-month dates; prior-month dates remain selectable through the 2nd of the month (matching the auto-submit for payment on the 3rd)
- Date picker defaults back to today

## Test plan (round 3)
- [ ] Confirm the July hold notice no longer appears on the form
- [ ] Confirm current-month (July) dates are selectable in the date picker
- [ ] Confirm the date picker defaults to today
