### PR TITLE
feat(project): switch budgeted hours to new FY Monday board

### DIFF
--- a/app/domains/project/repository.ts
+++ b/app/domains/project/repository.ts
@@ -299,13 +299,6 @@ export function projectRepository(): ProjectRepository {
               items {
                 id
                 name
-                column_values(types: dropdown) {
-                  ... on DropdownValue {
-                    column {
-                      id
-                    }
-                  }
-                }
               }
             }
           }
@@ -323,13 +316,6 @@ export function projectRepository(): ProjectRepository {
               items {
                 id
                 name
-                column_values(types: dropdown) {
-                  ... on DropdownValue {
-                    column {
-                      id
-                    }
-                  }
-                }
               }
             }
           }`;

--- a/app/domains/project/repository.ts
+++ b/app/domains/project/repository.ts
@@ -193,13 +193,14 @@ export function projectRepository(): ProjectRepository {
         //NOTE: Not using Monday API filtering by employeeId because it doesn't support filtering lookup columns
         let query = "";
            query = `{
-            boards(ids: 9709949287) {
+            boards(ids: 18418027639) {
               items_page(
                 limit: 500
                 query_params: {
                   rules: [
                     {
                       column_id: "group"
+                      # TODO: group id for the new FY board is not confirmed yet
                       compare_value: ["group_mkv0sxxj"]
                       operator: any_of
                     }
@@ -211,10 +212,11 @@ export function projectRepository(): ProjectRepository {
                   id
                   name
                   column_values(ids: [
-                    "lookup_mksmfdnr", 
+                    # TODO: employee email column may change on the new board — not confirmed yet
+                    "lookup_mksmfdnr",
                     "lookup_mkpvs1wj",
-                    "numeric_mknhqm6d", 
-                    "dropdown_mkttdgrw", 
+                    "numeric_mknhqm6d",
+                    "dropdown_mkttdgrw",
                     "color_mknhq0s3"
                   ]) {
                     id
@@ -249,10 +251,11 @@ export function projectRepository(): ProjectRepository {
                 id
                 name
                 column_values(ids: [
-                  "lookup_mksmfdnr", 
+                  # TODO: employee email column may change on the new board — not confirmed yet
+                  "lookup_mksmfdnr",
                   "lookup_mkpvs1wj",
-                  "numeric_mknhqm6d", 
-                  "dropdown_mkttdgrw", 
+                  "numeric_mknhqm6d",
+                  "dropdown_mkttdgrw",
                   "color_mknhq0s3"
                 ]) {
                   id
@@ -293,7 +296,7 @@ export function projectRepository(): ProjectRepository {
     fetchProjectColumnBAD: async (): Promise<Errorable<Record<string, string>>> => {
       try {
         const query = `{
-          boards(ids: 9709949287) {
+          boards(ids: 18418027639) {
             items_page(limit: 500) {
               cursor
               items {

--- a/app/domains/project/repository.ts
+++ b/app/domains/project/repository.ts
@@ -11,7 +11,6 @@ export interface ProjectRepository {
   fetchAllProjects(): Promise<Errorable<projectsByTypes[]>>;
   fetchProgramProjects(mondayProfileId: string): Promise<Errorable<ProgramProject[]>>;
   fetchAllBudgetedHours(): Promise<Errorable<any>>;
-  fetchProjectColumnBAD(): Promise<Errorable<Record<string, string>>>;
   fetchProjectSourceNames(): Promise<Errorable<string[]>>;
 }
 
@@ -288,89 +287,6 @@ export function projectRepository(): ProjectRepository {
         return {
           data: null,
           error: new Error("fetchAllBudgetedHours() went wrong"),
-        };
-      }
-    },
-    //NOTE: separate query because can't read dropdown column when fetching with column ids filter
-    //UPDATE: to delete, you are now able to fetch the column with the fitler now
-    fetchProjectColumnBAD: async (): Promise<Errorable<Record<string, string>>> => {
-      try {
-        const query = `{
-          boards(ids: 18418027639) {
-            items_page(limit: 500) {
-              cursor
-              items {
-                id
-                name
-                column_values(types: dropdown) {
-                  id
-                  column { id type title }
-                  text
-                  ... on DropdownValue {
-                    values { id label }
-                  }
-                }
-              }
-            }
-          }
-        }`;
-
-        let rawMondayData = await fetchMondayData(query);
-        let cursor: string | null = rawMondayData.data.boards[0].items_page.cursor;
-        let allItems = rawMondayData.data.boards[0].items_page.items;
-
-        // Handle pagination if there are more results
-        while (cursor) {
-          const cursorQuery = `{
-            next_items_page(limit: 500, cursor: "${cursor}") {
-              cursor
-              items {
-                id
-                name
-                column_values(types: dropdown) {
-                  id
-                  column { id type title }
-                  text
-                  ... on DropdownValue {
-                    values { id label }
-                  }
-                }
-              }
-            }
-          }`;
-
-          const rawAdditionalData = await fetchMondayData(cursorQuery);
-          allItems.push(...rawAdditionalData.data.next_items_page.items);
-          cursor = rawAdditionalData.data.next_items_page.cursor;
-        }
-     
-        // Create a mapping of item ID to project name
-        const projectNamesMap: Record<string, string> = {};
-        
-        allItems.forEach((item: any) => {
-          // Find the dropdown column for project names (dropdown_mkttdgrw)
-          // Search through all column_values to find the one with the correct column ID
-          const projectNameColumn = item.column_values?.find(
-            (colValue: any) => colValue.column?.id === "dropdown_mkttdgrw"
-          );
-          
-          // Extract project name from dropdown values array
-          if (projectNameColumn && projectNameColumn.values && projectNameColumn.values.length > 0) {
-            // Get the label from the first value in the dropdown
-            const projectName = projectNameColumn.values[0]?.label;
-            if (projectName) {
-              projectNamesMap[item.id] = projectName;
-            }
-          }
-        });
-
-        console.log(`Fetched project names for ${Object.keys(projectNamesMap).length} items`);
-        return { data: projectNamesMap, error: null };
-      } catch (e) {
-        console.error("Error in fetchProjectNames:", e);
-        return {
-          data: null,
-          error: new Error("fetchProjectNames() went wrong"),
         };
       }
     },

--- a/app/domains/project/repository.ts
+++ b/app/domains/project/repository.ts
@@ -199,8 +199,7 @@ export function projectRepository(): ProjectRepository {
                   rules: [
                     {
                       column_id: "group"
-                      # TODO: group id for the new FY board is not confirmed yet
-                      compare_value: ["group_mkv0sxxj"]
+                      compare_value: ["group_mm4cyf8"]
                       operator: any_of
                     }
                   ]
@@ -211,11 +210,10 @@ export function projectRepository(): ProjectRepository {
                   id
                   name
                   column_values(ids: [
-                    # TODO: employee email column may change on the new board — not confirmed yet
-                    "lookup_mksmfdnr",
+                    "lookup_mm5b2k23",
                     "lookup_mkpvs1wj",
                     "numeric_mknhqm6d",
-                    "dropdown_mkttdgrw",
+                    "dropdown_mm5h458x",
                     "color_mknhq0s3"
                   ]) {
                     id
@@ -250,11 +248,10 @@ export function projectRepository(): ProjectRepository {
                 id
                 name
                 column_values(ids: [
-                  # TODO: employee email column may change on the new board — not confirmed yet
-                  "lookup_mksmfdnr",
+                  "lookup_mm5b2k23",
                   "lookup_mkpvs1wj",
                   "numeric_mknhqm6d",
-                  "dropdown_mkttdgrw",
+                  "dropdown_mm5h458x",
                   "color_mknhq0s3"
                 ]) {
                   id

--- a/app/domains/project/service.ts
+++ b/app/domains/project/service.ts
@@ -6,7 +6,7 @@ export interface ProjectService {
   fetchAllProjects: () => Promise<{ data: projectsByTypes[] | null }>;
   fetchProgramProjects: () => Promise<{ data: string[] | null | undefined }>;
   fetchProgramProjectsStaffing: (mondayProfileId: string) => Promise<Errorable<ProgramProject[]>>;
-  // Prefer designated employee ID (lookup_mkpvs1wj). Fall back to employee email (lookup_mksmfdnr).
+  // Prefer designated employee ID (lookup_mkpvs1wj). Fall back to employee email (lookup_mm5b2k23).
   fetchBudgetedHoursByEmployee: (
     employeeId?: string | null,
     employeeEmail?: string | null
@@ -33,7 +33,7 @@ function buildBudgetedHoursIndex(allItems: any[]): BudgetedHoursIndex {
 
     // Transform item to EmployeeBudgetedHours format
     const emailValue =
-      item.column_values?.find((col: any) => col.id === "lookup_mksmfdnr")?.display_value ||
+      item.column_values?.find((col: any) => col.id === "lookup_mm5b2k23")?.display_value ||
       "";
     const emailValueTrimmed = typeof emailValue === "string" ? emailValue.trim().toLowerCase() : "";
 
@@ -44,7 +44,7 @@ function buildBudgetedHoursIndex(allItems: any[]): BudgetedHoursIndex {
       itemId: item.id,
       itemName: item.name,
       email: emailValueTrimmed,
-      projectName: item.column_values?.find((col: any) => col.id === "dropdown_mkttdgrw")?.text || "",
+      projectName: item.column_values?.find((col: any) => col.id === "dropdown_mm5h458x")?.text || "",
       projectRole: item.column_values?.find((col: any) => col.id === "color_mknhq0s3")?.label || 
                    item.column_values?.find((col: any) => col.id === "color_mknhq0s3")?.text || "",
       budgetedHours: parseFloat(item.column_values?.find((col: any) => col.id === "numeric_mknhqm6d")?.text || "0") || 0


### PR DESCRIPTION
## Summary

Switches the Weekly Project Log's budgeted-hours source from Monday board `9709949287` to the new fiscal year board **`18418027639`** (FY27 Budgeted Allocation Database), and confirms the group/column IDs specific to that board.

Closes #144

## Confirmed board mapping

- **Group**: `group_mm4cyf8` ("FY27 Staffing Assignments") — only items in this top group are connected; the board's other group ("PENDING") is excluded.
- **Project name**: `dropdown_mm5h458x` ("FY27 Project Names"). The old `dropdown_mkttdgrw` column still exists on this board but is now labeled "FY26 Project Name" and is no longer the source of truth.
- **Employee email**: `lookup_mm5b2k23` (mirrored "Email" column). The old `lookup_mksmfdnr` column doesn't exist on the new board.
- **Employee ID** (`lookup_mkpvs1wj`), **Budgeted Hours/Week** (`numeric_mknhqm6d`), and **Project Role** (`color_mknhq0s3`) kept the same column IDs as the old board, so no change was needed there.

Also removed the dead `fetchProjectColumnBAD` method and unused `column_values(types: dropdown)` payload from `fetchProjectSourceNames` (no behavior change).

## Verification

- Confirmed the group/column IDs directly against the new board's live schema via the Monday API.
- `npm run typecheck` and `npm run build` both pass.
- Simulated the Weekly Project Log form's data fetch for a real employee (Jake Kettlewell) and confirmed the API returns his correct project assignments, roles, and budgeted hours (e.g. `TN_Compass Community` at 7.5 hrs/week), matching what's on the live board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)