### PR TITLE
feat(coach-log): include sub-school in the duplicate guard when required

### DIFF
--- a/app/components/coach-log/coach-log-form.tsx
+++ b/app/components/coach-log/coach-log-form.tsx
@@ -107,12 +107,26 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   const [failedCoachees, setFailedCoachees] = useState<string[]>([]);
   const [showErrorBanner, setShowErrorBanner] = useState(false);
 
-  const { district, school, nycCoachType, canceled, sessionDate } =
+  const { district, school, nycCoachType, canceled, sessionDate, subSchool } =
     form.values;
   const readsIsPLSession = form.values.readsIsPLSession;
 
-  // One log per coach + district + school + date — checked as soon as those are
-  // chosen so the coach is warned before filling out the form.
+  // Sub-school options are filtered from the loader map by district + school.
+  const subSchoolOptions = useMemo(
+    () => subSchools[subSchoolKey(district, school)] ?? [],
+    [subSchools, district, school]
+  );
+
+  // Sub-school shows for D75 + Solves, but only when the sheet actually has
+  // sub-schools for this district + school combo (otherwise there's nothing to
+  // pick, so we hide the question rather than show an empty dropdown).
+  const showSubSchool =
+    shouldShowSubSchool(district, nycCoachType) && subSchoolOptions.length > 0;
+
+  // One log per coach + district + school + date — plus sub-school when the form
+  // requires one, so different sub-schools on the same date aren't collapsed
+  // into a single log. Checked as soon as those are chosen so the coach is
+  // warned before filling out the form.
   const {
     duplicateExists,
     checking: checkingDuplicate,
@@ -125,6 +139,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
     school,
     sessionDate,
     nycCoachType,
+    subSchool: showSubSchool ? subSchool : "",
   });
 
   // While the check is running or a duplicate exists, the activity questions are
@@ -132,18 +147,7 @@ export const CoachLogForm = ({ districts, subSchools }: Props) => {
   // change district/school/date above to resolve it).
   const lockActivities = checkingDuplicate || duplicateExists;
 
-  // Sub-school options are filtered from the loader map by district + school.
-  const subSchoolOptions = useMemo(
-    () => subSchools[subSchoolKey(district, school)] ?? [],
-    [subSchools, district, school]
-  );
-
   const showNycCoachType = isNycCoachTypeDistrict(district);
-  // Sub-school shows for D75 + Solves, but only when the sheet actually has
-  // sub-schools for this district + school combo (otherwise there's nothing to
-  // pick, so we hide the question rather than show an empty dropdown).
-  const showSubSchool =
-    shouldShowSubSchool(district, nycCoachType) && subSchoolOptions.length > 0;
   const showEarlyChildhood = shouldShowEarlyChildhood(district, nycCoachType);
   const showReads = shouldShowReads(district, nycCoachType);
   const showSolves = shouldShowSolves(district, nycCoachType);

--- a/app/components/coach-log/hooks/use-duplicate-check.ts
+++ b/app/components/coach-log/hooks/use-duplicate-check.ts
@@ -3,8 +3,8 @@ import type { CoachLogIdentity } from "~/domains/coach-log/model";
 
 /**
  * Checks whether a coach log already exists for this coach + district + school +
- * date (the one-log-per-day rule). Re-runs whenever any of those change, calling
- * the `/api/coach-log/exists` endpoint, and exposes:
+ * sub-school + date (the one-log-per-day rule). Re-runs whenever any of those
+ * change, calling the `/api/coach-log/exists` endpoint, and exposes:
  *  - `duplicateExists`: true when a matching log was found
  *  - `checking`: true while the check is in flight
  *  - `checkError`: true when the check couldn't complete (so the form can warn
@@ -15,8 +15,15 @@ import type { CoachLogIdentity } from "~/domains/coach-log/model";
  * authoritative guard still lives in the submit route.
  */
 export function useDuplicateCheck(query: CoachLogIdentity) {
-  const { coachMondayId, coachName, district, school, sessionDate, nycCoachType } =
-    query;
+  const {
+    coachMondayId,
+    coachName,
+    district,
+    school,
+    sessionDate,
+    nycCoachType,
+    subSchool,
+  } = query;
   const [duplicateExists, setDuplicateExists] = useState(false);
   const [checking, setChecking] = useState(false);
   const [checkError, setCheckError] = useState(false);
@@ -42,6 +49,7 @@ export function useDuplicateCheck(query: CoachLogIdentity) {
         school,
         sessionDate,
         nycCoachType,
+        subSchool,
       }),
     })
       .then((r) => r.json())
@@ -68,7 +76,15 @@ export function useDuplicateCheck(query: CoachLogIdentity) {
     return () => {
       cancelled = true;
     };
-  }, [coachMondayId, coachName, district, school, sessionDate, nycCoachType]);
+  }, [
+    coachMondayId,
+    coachName,
+    district,
+    school,
+    sessionDate,
+    nycCoachType,
+    subSchool,
+  ]);
 
   return { duplicateExists, checking, checkError, setDuplicateExists };
 }

--- a/app/domains/coach-log/model.ts
+++ b/app/domains/coach-log/model.ts
@@ -65,8 +65,8 @@ export type CoachOption = {
 
 /**
  * The fields that uniquely identify a coach log for the duplicate check: one log
- * per coach + district + school + date. `coachMondayId` is preferred for the
- * coach match; `coachName` (the item name) is the fallback.
+ * per coach + district + school + sub-school + date. `coachMondayId` is preferred
+ * for the coach match; `coachName` (the item name) is the fallback.
  */
 export type CoachLogIdentity = {
   coachMondayId: string;
@@ -78,6 +78,11 @@ export type CoachLogIdentity = {
    * Reads) for the same school/date, so it's part of the duplicate key. Empty
    * for non-NYC districts (matches other empty-coach-type logs). */
   nycCoachType: string;
+  /** Sub-school — when the form requires one (D75 + Solves), the same coach can
+   * log different sub-schools for the same school/date, so it's part of the
+   * duplicate key. Empty when sub-school doesn't apply (matches other
+   * empty-sub-school logs). */
+  subSchool: string;
 };
 
 /** One 1:1 coaching entry. Each row becomes a Monday subitem on submission. */

--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -321,12 +321,14 @@ export function coachLogRepository(): CoachLogRepository {
     },
 
     // True if a coach log already exists for this coach + district + school +
-    // date + coach type (one-log-per-day rule; cancelled logs count). Narrows
-    // the board to the district + school via Monday filters, then matches coach
-    // + date + coach type exactly in JS (the coach matches on the people column
-    // id, falling back to the item name). Coach type is part of the key because
-    // one coach can log e.g. a Solves and a Reads session for the same
-    // school/date. Returns false when there's no date to dedupe on.
+    // date + coach type + sub-school (one-log-per-day rule; cancelled logs
+    // count). Narrows the board to the district + school via Monday filters,
+    // then matches coach + date + coach type + sub-school exactly in JS (the
+    // coach matches on the people column id, falling back to the item name).
+    // Coach type is part of the key because one coach can log e.g. a Solves and
+    // a Reads session for the same school/date; sub-school likewise lets a coach
+    // log different sub-schools for the same school/date (empty == empty when
+    // sub-school doesn't apply). Returns false when there's no date to dedupe on.
     hasExistingLog: async (query: CoachLogIdentity) => {
       try {
         const date = query.sessionDate.trim();
@@ -337,6 +339,7 @@ export function coachLogRepository(): CoachLogRepository {
         const coachId = query.coachMondayId.trim();
         const coachName = normalize(query.coachName);
         const coachType = normalize(query.nycCoachType);
+        const subSchool = normalize(query.subSchool);
 
         // Escape values interpolated into the GraphQL rule strings.
         const esc = (v: string) =>
@@ -359,7 +362,7 @@ export function coachLogRepository(): CoachLogRepository {
         }
         const rules = `[${ruleParts.join(", ")}]`;
 
-        const columnIds = `["text88__1","text5__1","date__1","people__1","text13__1"]`;
+        const columnIds = `["text88__1","text5__1","date__1","people__1","text13__1","text_mm465e65"]`;
         const buildQuery = (cursor: string | null) =>
           cursor
             ? `{ next_items_page(limit: 500, cursor: "${cursor}") { cursor items { name column_values(ids:${columnIds}) { id text value } } } }`
@@ -392,13 +395,25 @@ export function coachLogRepository(): CoachLogRepository {
           // Coach type must also match (empty == empty for non-NYC districts),
           // so a coach's Solves and Reads logs for the same day don't collide.
           const coachTypeOk = normalize(col("text13__1")?.text) === coachType;
+          // Sub-school must also match (empty == empty when it doesn't apply),
+          // so a coach's logs for different sub-schools of the same school/date
+          // don't collide.
+          const subSchoolOk =
+            normalize(col("text_mm465e65")?.text) === subSchool;
           // Prefer matching by Monday profile id; fall back to the item name
           // (the coach name) only when no id is available.
           const coachOk =
             coachId !== ""
               ? peopleIds.includes(coachId)
               : coachName !== "" && normalize(item.name) === coachName;
-          return districtOk && schoolOk && dateOk && coachOk && coachTypeOk;
+          return (
+            districtOk &&
+            schoolOk &&
+            dateOk &&
+            coachOk &&
+            coachTypeOk &&
+            subSchoolOk
+          );
         };
 
         let response = await fetchMondayData(buildQuery(null));

--- a/app/routes/api.coach-log.exists.tsx
+++ b/app/routes/api.coach-log.exists.tsx
@@ -4,8 +4,8 @@ import { coachLogRepository } from "~/domains/coach-log/repository";
 import { coachLogService } from "~/domains/coach-log/service";
 
 // Pre-submit check: does a coach log already exist for this coach + district +
-// school + date? Used by the form to warn early and disable Submit. The submit
-// route enforces the same rule authoritatively.
+// school + sub-school + date? Used by the form to warn early and disable Submit.
+// The submit route enforces the same rule authoritatively.
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (request.method !== "POST") {
     return json({ error: "Method not allowed" }, { status: 405 });
@@ -26,6 +26,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       school,
       sessionDate,
       nycCoachType: query.nycCoachType ?? "",
+      subSchool: query.subSchool ?? "",
     });
     if (error) {
       console.error("Error checking for existing coach log:", error);

--- a/app/routes/api.coach-log.submit.tsx
+++ b/app/routes/api.coach-log.submit.tsx
@@ -101,9 +101,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   try {
     // ---- Duplicate guard ------------------------------------------------
-    // One log per coach + district + school + date + coach type (cancelled logs
-    // count). This is the authoritative check; the form also pre-checks for a
-    // better UX.
+    // One log per coach + district + school + date + coach type + sub-school
+    // (cancelled logs count). This is the authoritative check; the form also
+    // pre-checks for a better UX. `subSchool` is already gated to "" by the
+    // client when sub-school doesn't apply, so it only narrows the key for
+    // D75 + Solves logs.
     const service = coachLogService(coachLogRepository());
     const duplicate = await service.hasExistingLog({
       coachMondayId,
@@ -112,6 +114,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       school,
       sessionDate,
       nycCoachType,
+      subSchool,
     });
     if (duplicate.data) {
       return new Response(null, {


### PR DESCRIPTION
## Problem
The coach-log duplicate guard ("one log per coach + district + school + date") ignored **sub-school**. For D75 + Solves sessions — where a coach picks a sub-school — logging two different sub-schools for the same school on the same date was wrongly flagged as a duplicate and blocked.

## Change
Add `subSchool` to the duplicate key, gated so it participates **only when the sub-school question is required** (D75 + Solves with sub-school options present). When sub-school doesn't apply it stays `""` and matches `""`, so behavior for every other coach type is unchanged.

Threaded through all five layers:
- `app/domains/coach-log/model.ts` — `subSchool` added to `CoachLogIdentity`.
- `app/components/coach-log/hooks/use-duplicate-check.ts` — sends it in the request body + effect deps.
- `app/components/coach-log/coach-log-form.tsx` — passes `subSchool` gated on `showSubSchool`.
- `app/routes/api.coach-log.exists.tsx` — forwards it to the pre-check.
- `app/routes/api.coach-log.submit.tsx` — passes it to the authoritative check.
- `app/domains/coach-log/repository.ts` — fetches + exactly matches the sub-school column (`text_mm465e65`).

## Verification
- `npm run typecheck` passes.
- Ran the app; `POST /api/coach-log/exists` with the new `subSchool` field returns 200 and queries the live board successfully (confirms the added column id is valid).

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)