### PR TITLE
fix(coach-log): guard against a missing People-column link on the employee board

### DIFF
--- a/app/domains/employee/repository.ts
+++ b/app/domains/employee/repository.ts
@@ -48,7 +48,7 @@ export function employeeRepository(): EmployeeRepository {
           result.data.boards[0].items_page.items[0]["column_values"].find(
             (column: { id: string; persons_and_teams: { id: string }[] }) =>
               column.id === "people"
-          )?.persons_and_teams[0]["id"] || "";
+          )?.persons_and_teams[0]?.id || "";
         const employeeId: string =
           result.data.boards[0].items_page.items[0]["column_values"].find(
             (column: { id: string; text: string }) => column.id === "text_mkpt2c0x"

--- a/app/routes/coach-log-form.tsx
+++ b/app/routes/coach-log-form.tsx
@@ -2,6 +2,7 @@ import { json } from "@remix-run/node";
 import { useLoaderData, type ShouldRevalidateFunction } from "@remix-run/react";
 import { useSession } from "~/components/auth/hooks/useSession";
 import { CoachLogForm } from "~/components/coach-log/coach-log-form";
+import { AccessDeniedState } from "~/components/vendor-payment-form/access-denied-state";
 import { coachLogRepository } from "~/domains/coach-log/repository";
 import { coachLogService } from "~/domains/coach-log/service";
 import { LoadingSpinner } from "~/utils/LoadingSpinner";
@@ -45,6 +46,16 @@ export default function CoachLogFormRoute() {
 
   if (isSessionLoading || mondayProfile === null) {
     return <LoadingSpinner message="Loading session..." />;
+  }
+
+  // FTE/PTE employees are resolved via the employee board's "people" column,
+  // which links their Monday user account. Coaches/facilitators resolved via
+  // the coach/facilitator board fallback never have this link (that board
+  // doesn't carry a person id), so only require it outside that fallback path.
+  if (mondayProfile.businessFunction !== "contractor" && !mondayProfile.mondayProfileId) {
+    return (
+      <AccessDeniedState errorMessage="Your Monday profile isn't fully linked yet (missing the People-column assignment on the Employee board), so we can't attribute coach log submissions to you. Please contact the operations team to get this fixed, then try again." />
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixes #148
- `fetchEmployee()` crashed on an unguarded array index when an FTE/PTE employee's "people" column (Monday person link) had nobody assigned, causing login to fail entirely even though the employee's email matched exactly on the board.
- Since `mondayProfileId` is written into Monday's people columns on coach-log/participant-roster submission (and used to scope the duplicate-log check), the coach-log route now shows a clear access-denied message when an FTE/PTE profile is missing this link, instead of allowing a submission that silently omits the person column.
- Coaches/facilitators resolved via the contractor fallback board are exempt from this check — that path never carries a person id by design.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Reproduced the crash locally against the real employee board row (empty `persons_and_teams`) and confirmed the fix no longer throws
- [ ] Confirm the affected employee's Monday "people" column gets a person assigned, then verify she can log in and submit a coach log

🤖 Generated with [Claude Code](https://claude.com/claude-code)