### PR TITLE
feat(coach-log): switch Group Coaching Name to free text with Nisa Group ID sync

### DIFF
--- a/app/components/coach-log/participant-roster/build-submission.ts
+++ b/app/components/coach-log/participant-roster/build-submission.ts
@@ -25,7 +25,7 @@ export function buildParticipantRosterSubmission(
     contentAreas: values.contentAreas,
     contentAreaOther: values.contentAreaOther,
     grades: values.grades,
-    groupNumbers: values.groupNumbers,
+    groupCoachingName: values.groupCoachingName.trim(),
     district: values.district,
     school: values.school,
   };

--- a/app/components/coach-log/participant-roster/constants.ts
+++ b/app/components/coach-log/participant-roster/constants.ts
@@ -46,16 +46,3 @@ export const GRADE_OPTIONS = [
   "Grade 11",
   "Grade 12",
 ];
-
-export const GROUP_NUMBER_OPTIONS = [
-  "Group 1",
-  "Group 2",
-  "Group 3",
-  "Group 4",
-  "Group 5",
-  "Group 6",
-  "Group 7",
-  "Group 8",
-  "Group 9",
-  "Group 10",
-];

--- a/app/components/coach-log/participant-roster/hooks/use-participant-roster-form.ts
+++ b/app/components/coach-log/participant-roster/hooks/use-participant-roster-form.ts
@@ -11,7 +11,7 @@ export type ParticipantRosterValues = {
   contentAreas: string[];
   contentAreaOther: string;
   grades: string[];
-  groupNumbers: string[];
+  groupCoachingName: string;
   district: string;
   school: string;
 };
@@ -26,7 +26,7 @@ const INITIAL_VALUES: ParticipantRosterValues = {
   contentAreas: [],
   contentAreaOther: "",
   grades: [],
-  groupNumbers: [],
+  groupCoachingName: "",
   district: "",
   school: "",
 };

--- a/app/components/coach-log/participant-roster/participant-roster-form.tsx
+++ b/app/components/coach-log/participant-roster/participant-roster-form.tsx
@@ -1,4 +1,5 @@
 import {
+  Autocomplete,
   Button,
   Loader,
   MultiSelect,
@@ -8,7 +9,7 @@ import {
   TextInput,
 } from "@mantine/core";
 import { IconAlertTriangle, IconCheck, IconX } from "@tabler/icons-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { DistrictWithSchools } from "~/domains/coach-log/model";
 import { useSession } from "../../auth/hooks/useSession";
 import { useCoachOverride } from "../hooks/use-coach-override";
@@ -17,7 +18,6 @@ import { buildParticipantRosterSubmission } from "./build-submission";
 import {
   CONTENT_AREA_OPTIONS,
   GRADE_OPTIONS,
-  GROUP_NUMBER_OPTIONS,
   OTHER_OPTION,
   PARTICIPANT_ROLE_OPTIONS,
   SUPPORT_OPTIONS,
@@ -57,8 +57,9 @@ export const ParticipantRosterForm = ({ districts }: Props) => {
   // the values, but a controlled searchable Select keeps its displayed text
   // until the field is remounted — so we key the form on this counter.
   const [resetKey, setResetKey] = useState(0);
+  const [groupNameOptions, setGroupNameOptions] = useState<string[]>([]);
 
-  const { district, role, contentAreas } = form.values;
+  const { district, school, role, contentAreas } = form.values;
 
   const districtOptions = useMemo(
     () => districts.map((d) => d.district),
@@ -75,6 +76,33 @@ export const ParticipantRosterForm = ({ districts }: Props) => {
     form.setFieldValue("district", value || "");
     form.setFieldValue("school", "");
   };
+
+  // Suggest Group Coaching Names already on the roster for this district +
+  // school, once both are selected.
+  useEffect(() => {
+    if (!district || !school) {
+      setGroupNameOptions([]);
+      return;
+    }
+
+    let cancelledFetch = false;
+    fetch("/api/participant-roster/group-names", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ district, school }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelledFetch) setGroupNameOptions(data.groupNames || []);
+      })
+      .catch(() => {
+        if (!cancelledFetch) setGroupNameOptions([]);
+      });
+
+    return () => {
+      cancelledFetch = true;
+    };
+  }, [district, school]);
 
   const handleSubmit = async (values: ParticipantRosterValues) => {
     setShowErrorBanner(false);
@@ -213,17 +241,6 @@ export const ParticipantRosterForm = ({ districts }: Props) => {
       </div>
 
       <div className="flex flex-col gap-1">
-        <h1 className="font-medium text-lg">
-          If this participant receives group coaching, select their Group Number.
-        </h1>
-        <MultiSelect
-          placeholder="Select all that apply"
-          data={GROUP_NUMBER_OPTIONS}
-          {...form.getInputProps("groupNumbers")}
-        />
-      </div>
-
-      <div className="flex flex-col gap-1">
         <h1 className="font-medium text-lg">Please select your district*</h1>
         <Select
           value={district || null}
@@ -246,6 +263,22 @@ export const ParticipantRosterForm = ({ districts }: Props) => {
           searchable
           disabled={!district}
           {...form.getInputProps("school")}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <h1 className="font-medium text-lg">
+          If this participant receives group coaching, enter their Group
+          Coaching Name.
+        </h1>
+        <Autocomplete
+          placeholder={
+            district && school
+              ? "Group coaching name"
+              : "Select a district and school first for suggestions"
+          }
+          data={groupNameOptions}
+          {...form.getInputProps("groupCoachingName")}
         />
       </div>
 

--- a/app/domains/participant-roster/model.ts
+++ b/app/domains/participant-roster/model.ts
@@ -18,7 +18,7 @@ export type ParticipantRosterSubmission = {
   contentAreas: string[];
   contentAreaOther: string;
   grades: string[];
-  groupNumbers: string[];
+  groupCoachingName: string;
   district: string;
   school: string;
 };
@@ -36,7 +36,10 @@ export type ParticipantRosterEntry = {
   supports: string[];
   contentAreas: string[];
   grades: string[];
-  groupNumbers: string[];
+  groupCoachingName: string;
+  /** UUID for the participant's group, shared by every roster entry with the
+   * same groupCoachingName so Nisa can treat them as one group. */
+  nisaGroupId: string;
   district: string;
   school: string;
 };

--- a/app/domains/participant-roster/repository.ts
+++ b/app/domains/participant-roster/repository.ts
@@ -10,8 +10,8 @@ import { ParticipantRosterEntry } from "./model";
 //   email_mktht3ax     = Participant Email     email_mkthfrq7 = Responder's Email
 //   dropdown_mkth66bp  = Participant Role       dropdown_mktbega2 = Service Type
 //   dropdown_mkth57c8  = Content Area           dropdown_mktbacaf = Grade Level(s)
-//   dropdown_mkwt4nzg  = Group Coaching Number  coaching_partners = Site/District
-//   short_text66       = School
+//   coaching_partners  = Site/District           short_text66 = School
+//   text_mm5w13st      = Group Coaching Name     text_mm5w6tnt = Nisa Group ID
 export const PARTICIPANT_ROSTER_BOARD_ID = 18416567790;
 const ROSTER_GROUP_ID = "group_mktb1yqy";
 
@@ -23,6 +23,9 @@ const labels = (values: string[]) => values.join(",");
 
 const normalize = (v: unknown) => String(v ?? "").trim().toLowerCase();
 
+const escQueryValue = (v: string) =>
+  v.trim().replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
 export interface ParticipantRosterRepository {
   createParticipant(entry: ParticipantRosterEntry): Promise<Errorable<string>>;
   /** True if a participant with this email is already on the roster for the
@@ -32,6 +35,15 @@ export interface ParticipantRosterRepository {
     district: string,
     school: string
   ): Promise<Errorable<boolean>>;
+  /** The existing Nisa Group ID for another roster entry with this exact
+   * Group Coaching Name, or null if the name is new to the board. */
+  findGroupId(groupCoachingName: string): Promise<Errorable<string | null>>;
+  /** Distinct Group Coaching Names already on the roster for this district +
+   * school, for the group-name autocomplete. */
+  fetchGroupCoachingNames(
+    district: string,
+    school: string
+  ): Promise<Errorable<string[]>>;
 }
 
 export function participantRosterRepository(): ParticipantRosterRepository {
@@ -61,8 +73,10 @@ export function participantRosterRepository(): ParticipantRosterRepository {
           columns.dropdown_mkth57c8 = labels(entry.contentAreas); // Content Area
         if (entry.grades.length)
           columns.dropdown_mktbacaf = labels(entry.grades); // Grade Level(s)
-        if (entry.groupNumbers.length)
-          columns.dropdown_mkwt4nzg = labels(entry.groupNumbers); // Group Number
+        if (entry.groupCoachingName) {
+          columns.text_mm5w13st = entry.groupCoachingName; // Group Coaching Name
+          columns.text_mm5w6tnt = entry.nisaGroupId; // Nisa Group ID
+        }
 
         const query =
           "mutation ($itemName: String!, $columnVals: JSON!, $groupName: String!) { create_item (board_id: " +
@@ -102,9 +116,7 @@ export function participantRosterRepository(): ParticipantRosterRepository {
         const wantDistrict = normalize(district);
         const wantSchool = normalize(school);
 
-        const esc = (v: string) =>
-          v.trim().replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-        const rules = `[{column_id: "email_mktht3ax", operator: contains_text, compare_value: "${esc(email)}"}, {column_id: "coaching_partners", operator: contains_text, compare_value: "${esc(district)}"}, {column_id: "short_text66", operator: contains_text, compare_value: "${esc(school)}"}]`;
+        const rules = `[{column_id: "email_mktht3ax", operator: contains_text, compare_value: "${escQueryValue(email)}"}, {column_id: "coaching_partners", operator: contains_text, compare_value: "${escQueryValue(district)}"}, {column_id: "short_text66", operator: contains_text, compare_value: "${escQueryValue(school)}"}]`;
         const columnIds = `["email_mktht3ax","coaching_partners","short_text66"]`;
         const buildQuery = (cursor: string | null) =>
           cursor
@@ -139,6 +151,110 @@ export function participantRosterRepository(): ParticipantRosterRepository {
         return {
           data: null,
           error: new Error("participantExists() went wrong"),
+        };
+      }
+    },
+
+    // Group-id lookup: narrow the board server-side by Group Coaching Name
+    // (contains_text — same substring caveat as above), then confirm an exact
+    // match in JS and return that entry's existing Nisa Group ID so every
+    // participant in the same named group ends up sharing one id.
+    findGroupId: async (groupCoachingName) => {
+      try {
+        const wantName = normalize(groupCoachingName);
+        if (!wantName) return { data: null, error: null };
+
+        const rules = `[{column_id: "text_mm5w13st", operator: contains_text, compare_value: "${escQueryValue(groupCoachingName)}"}]`;
+        const columnIds = `["text_mm5w13st","text_mm5w6tnt"]`;
+        const buildQuery = (cursor: string | null) =>
+          cursor
+            ? `{ next_items_page(limit: 500, cursor: "${cursor}") { cursor items { column_values(ids:${columnIds}) { id text } } } }`
+            : `{ boards(ids: ${PARTICIPANT_ROSTER_BOARD_ID}) { items_page(limit: 500, query_params: {rules: ${rules}}) { cursor items { column_values(ids:${columnIds}) { id text } } } } }`;
+
+        const matchedGroupId = (item: any): string | null => {
+          const col = (id: string) =>
+            item.column_values.find((c: any) => c.id === id);
+          if (normalize(col("text_mm5w13st")?.text) !== wantName) return null;
+          return col("text_mm5w6tnt")?.text || null;
+        };
+
+        let response = await fetchMondayData(buildQuery(null));
+        let page = response.data.boards[0].items_page;
+        for (const item of page.items) {
+          const groupId = matchedGroupId(item);
+          if (groupId) return { data: groupId, error: null };
+        }
+
+        let cursor: string | null = page.cursor;
+        while (cursor) {
+          response = await fetchMondayData(buildQuery(cursor));
+          page = response.data.next_items_page;
+          for (const item of page.items) {
+            const groupId = matchedGroupId(item);
+            if (groupId) return { data: groupId, error: null };
+          }
+          cursor = page.cursor;
+        }
+
+        return { data: null, error: null };
+      } catch (e) {
+        console.error(e);
+        return {
+          data: null,
+          error: new Error("findGroupId() went wrong"),
+        };
+      }
+    },
+
+    // Autocomplete source: narrow the board server-side by district + school
+    // (contains_text — same substring caveat as above), confirm an exact
+    // match in JS, then return the distinct, sorted Group Coaching Names.
+    fetchGroupCoachingNames: async (district, school) => {
+      try {
+        const wantDistrict = normalize(district);
+        const wantSchool = normalize(school);
+        if (!wantDistrict || !wantSchool) return { data: [], error: null };
+
+        const rules = `[{column_id: "coaching_partners", operator: contains_text, compare_value: "${escQueryValue(district)}"}, {column_id: "short_text66", operator: contains_text, compare_value: "${escQueryValue(school)}"}]`;
+        const columnIds = `["text_mm5w13st","coaching_partners","short_text66"]`;
+        const buildQuery = (cursor: string | null) =>
+          cursor
+            ? `{ next_items_page(limit: 500, cursor: "${cursor}") { cursor items { column_values(ids:${columnIds}) { id text } } } }`
+            : `{ boards(ids: ${PARTICIPANT_ROSTER_BOARD_ID}) { items_page(limit: 500, query_params: {rules: ${rules}}) { cursor items { column_values(ids:${columnIds}) { id text } } } } }`;
+
+        const groupName = (item: any): string | null => {
+          const col = (id: string) =>
+            item.column_values.find((c: any) => c.id === id);
+          if (
+            normalize(col("coaching_partners")?.text) !== wantDistrict ||
+            normalize(col("short_text66")?.text) !== wantSchool
+          )
+            return null;
+          return col("text_mm5w13st")?.text || null;
+        };
+
+        let response = await fetchMondayData(buildQuery(null));
+        let page = response.data.boards[0].items_page;
+        let items: any[] = page.items;
+
+        let cursor: string | null = page.cursor;
+        while (cursor) {
+          response = await fetchMondayData(buildQuery(cursor));
+          page = response.data.next_items_page;
+          items = items.concat(page.items);
+          cursor = page.cursor;
+        }
+
+        const names = Array.from(
+          new Set(items.map(groupName).filter((n): n is string => !!n))
+        ).sort((a, b) => a.localeCompare(b));
+
+        return { data: names, error: null };
+      } catch (e) {
+        console.error(e);
+        return {
+          data: null,
+          error: new Error("fetchGroupCoachingNames() went wrong"),
         };
       }
     },

--- a/app/domains/participant-roster/service.ts
+++ b/app/domains/participant-roster/service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Errorable } from "~/utils/errorable";
 import {
   ParticipantRosterEntry,
@@ -20,13 +21,17 @@ export interface ParticipantRosterService {
     district: string,
     school: string
   ): Promise<Errorable<boolean>>;
+  fetchGroupCoachingNames(
+    district: string,
+    school: string
+  ): Promise<Errorable<string[]>>;
 }
 
 export function participantRosterService(
   repository: ParticipantRosterRepository
 ): ParticipantRosterService {
   return {
-    submitParticipant: (submission) => {
+    submitParticipant: async (submission) => {
       // Resolve "Other" write-ins: the single-select role becomes the typed
       // text; in the multi-select content areas, "Other" is swapped for it.
       const role =
@@ -42,6 +47,15 @@ export function participantRosterService(
         submission.lastName
       )}`.trim();
 
+      // New group name -> generate its Nisa Group ID; a name already on the
+      // roster -> reuse the existing id so the whole group shares one.
+      const groupCoachingName = submission.groupCoachingName.trim();
+      let nisaGroupId = "";
+      if (groupCoachingName) {
+        const existing = await repository.findGroupId(groupCoachingName);
+        nisaGroupId = existing.data ?? randomUUID();
+      }
+
       const entry: ParticipantRosterEntry = {
         coachMondayId: submission.coachMondayId,
         responderEmail: submission.responderEmail,
@@ -51,7 +65,8 @@ export function participantRosterService(
         supports: submission.supports,
         contentAreas,
         grades: submission.grades,
-        groupNumbers: submission.groupNumbers,
+        groupCoachingName,
+        nisaGroupId,
         district: submission.district,
         school: submission.school,
       };
@@ -61,5 +76,8 @@ export function participantRosterService(
 
     participantExists: (email, district, school) =>
       repository.participantExists(email, district, school),
+
+    fetchGroupCoachingNames: (district, school) =>
+      repository.fetchGroupCoachingNames(district, school),
   };
 }

--- a/app/routes/api.participant-roster.group-names.tsx
+++ b/app/routes/api.participant-roster.group-names.tsx
@@ -1,0 +1,34 @@
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { participantRosterRepository } from "~/domains/participant-roster/repository";
+import { participantRosterService } from "~/domains/participant-roster/service";
+
+// Returns the distinct Group Coaching Names already on the roster for a
+// given district + school, for the group-name autocomplete.
+export const action = async ({ request }: ActionFunctionArgs) => {
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  try {
+    const { district, school } = await request.json();
+    if (!district || !school) {
+      return json({ groupNames: [] });
+    }
+
+    const service = participantRosterService(participantRosterRepository());
+    const { data, error } = await service.fetchGroupCoachingNames(
+      district,
+      school
+    );
+    if (error) {
+      console.error("Error fetching group coaching names:", error);
+    }
+    return json({ groupNames: data || [] });
+  } catch (error) {
+    console.error("Error in participant-roster group-names API:", error);
+    return json(
+      { groupNames: [], error: "Failed to fetch group coaching names" },
+      { status: 500 }
+    );
+  }
+};


### PR DESCRIPTION
Closes #152

## Summary
- Participant Roster form: "Group Number" (restricted MultiSelect) → free-text "Group Coaching Name", matching the roster board's move to a text column (`text_mm5w13st`).
- On submit, a new group name gets a fresh UUID written to the new "Nisa Group ID" column (`text_mm5w6tnt`); an existing group name (matched against the roster board) reuses its existing UUID so all participants in the same group share one id.
- Group Coaching Name now autocompletes from existing roster entries scoped to the selected district + school (mirrors the existing coachee-autocomplete pattern); district/school selection moved above the group name question so those values are available first.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manually submit a participant with a brand-new group name and confirm a UUID lands in Nisa Group ID on the roster board
- [ ] Manually submit a second participant with the same group name and confirm it reuses the same Nisa Group ID
- [ ] Confirm the Group Coaching Name autocomplete suggests existing names once district + school are selected