### PR TITLE
fix(coach-log): escape district/school in fetchCoachees GraphQL rules

### DIFF
--- a/app/domains/coach-log/repository.ts
+++ b/app/domains/coach-log/repository.ts
@@ -184,9 +184,13 @@ export function coachLogRepository(): CoachLogRepository {
         const districtFilter = normalize(district);
         const schoolFilter = normalize(school);
 
-        let rules = `[{column_id: "coaching_partners", operator: contains_terms, compare_value: ["${districtFilter}"]}`;
+        // Escape values interpolated into the GraphQL rule strings.
+        const esc = (v: string) =>
+          v.trim().replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+        let rules = `[{column_id: "coaching_partners", operator: contains_terms, compare_value: ["${esc(districtFilter)}"]}`;
         if (schoolFilter && schoolFilter !== "all schools") {
-          rules += `, {column_id: "short_text66", operator: contains_text, compare_value: ["${schoolFilter}"]}`;
+          rules += `, {column_id: "short_text66", operator: contains_text, compare_value: ["${esc(schoolFilter)}"]}`;
         }
         rules += `]`;
 


### PR DESCRIPTION
Closes #154

## Summary
- `fetchCoachees` interpolated `district`/`school` into the Monday GraphQL `rules` string without escaping quotes/backslashes, letting a crafted request body break out of `compare_value` and inject arbitrary query rules.
- Applies the same `esc()` escaping `hasExistingLog` already uses.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manually confirm coachee lookup still returns correct results for a normal district + school